### PR TITLE
Handle System.PlatformNotSupported exception when checking to see if a proxy can be used.

### DIFF
--- a/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -292,7 +292,14 @@ namespace Microsoft.Net.Http.Client
                 request.SetAddressLineProperty(pathAndQuery);
             }
 
-            if (!UseProxy || Proxy.IsBypassed(request.RequestUri))
+            try
+            {
+                if (!UseProxy || Proxy.IsBypassed(request.RequestUri))
+                {
+                    return ProxyMode.None;
+                }
+            }
+            catch (System.PlatformNotSupportedException)
             {
                 return ProxyMode.None;
             }


### PR DESCRIPTION
When running on DotNet Core on Linux, the ```System.PlatformNotSupported``` was firing when checking for proxy bypass. I could not see any way to set ```UseProxy``` to false from client code, and so propose that this exception is handled to enable functionality on platforms that don't support a proxy.

If a proxy is in fact required on a platform that doesn't support it, I expect the call to ```Proxy.GetProxy()``` to still fail as expected.