### PR TITLE
Reduce memory consumption in Microsoft.Net.Http.Client, update tooling

### DIFF
--- a/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.xproj
+++ b/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.xproj
@@ -4,12 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>ec789466-95c7-4fab-9575-18b2ff55abd3</ProjectGuid>
     <RootNamespace>Docker.DotNet.BasicAuth</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -17,5 +18,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Docker.DotNet.X509/Docker.DotNet.X509.xproj
+++ b/Docker.DotNet.X509/Docker.DotNet.X509.xproj
@@ -4,12 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>3eb8c108-ead7-4a58-aacf-33d9149f4708</ProjectGuid>
     <RootNamespace>Docker.DotNet.X509</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -17,5 +18,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Docker.DotNet/Docker.DotNet.xproj
+++ b/Docker.DotNet/Docker.DotNet.xproj
@@ -4,12 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>a9c3e587-ddec-494b-96e2-bfb4fc34ec74</ProjectGuid>
     <RootNamespace>Docker.DotNet</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -17,5 +18,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedWriteStream.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedWriteStream.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Net.Http.Client
 {
     internal class ChunkedWriteStream : Stream
     {
-        private static readonly byte[] s_endContentBytes = Encoding.ASCII.GetBytes("0\r\n\r\n");
+        private static readonly byte[] s_EndContentBytes = Encoding.ASCII.GetBytes("0\r\n\r\n");
 
         private Stream _innerStream;
 
@@ -82,8 +82,7 @@ namespace Microsoft.Net.Http.Client
 
         public Task EndContentAsync(CancellationToken cancellationToken)
         {
-            var data = s_endContentBytes;
-            return _innerStream.WriteAsync(data, 0, data.Length, cancellationToken);
+            return _innerStream.WriteAsync(s_EndContentBytes, 0, s_EndContentBytes.Length, cancellationToken);
         }
     }
 }

--- a/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
@@ -64,9 +64,16 @@ namespace Microsoft.Net.Http.Client
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            try
             {
-                _responseStream.Dispose();
+                if (disposing)
+                {
+                    _responseStream.Dispose();
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
             }
         }
     }

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -12,7 +12,7 @@
         "portable-dnxcore50+net45+win8+wp8+wpa81"
       ],
       "dependencies": {
-        "System.Buffers": "4.0.0",
+        "System.Buffers": "4.0.0-rc3-23829",
         "System.IO": "4.0.11-rc3-23829",
         "System.IO.Pipes": "4.0.0-beta-23516",
         "System.Linq": "4.0.1-rc3-23829",
@@ -30,14 +30,22 @@
       }
     },
     "net46": {
+      "dependencies": {
+        "System.Buffers": "4.0.0"
+      },
       "frameworkAssemblies": {
         "System.Net.Http": "",
+        "System.Runtime": "",
         "System.Runtime.Serialization": ""
       }
     },
     "net45": {
+      "dependencies": {
+        "System.Buffers": "4.0.0"
+      },
       "frameworkAssemblies": {
         "System.Net.Http": "",
+        "System.Runtime": "",
         "System.Runtime.Serialization": ""
       }
     }

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -12,6 +12,7 @@
         "portable-dnxcore50+net45+win8+wp8+wpa81"
       ],
       "dependencies": {
+        "System.Buffers": "4.0.0",
         "System.IO": "4.0.11-rc3-23829",
         "System.IO.Pipes": "4.0.0-beta-23516",
         "System.Linq": "4.0.1-rc3-23829",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": ["."],
   "sdk": {
-    "version": "1.0.0-rc2-20221"
+    "version": "1.0.0-preview2-003121"
   }
 }


### PR DESCRIPTION
Hi! I looked into the code for this project and noticed there were a few places where performance could be improved. I'll try to break down the changes I made here:

- Cache the bytes written in `ChunkedWriteStream.EndContentAsync`
- Use a pooled array from `System.Buffers.ArrayPool` in `BufferedReadStream` (I added `System.Buffers` as a dependency)
- Call `base.Dispose` in `HttpConnectionResponseContent` (since `HttpContent.Dispose` actually does work)

I also made a few other changes with the tooling, to make it easier to build/setup the project:

- Convert the DNX `.xproj` files to use the CLI
- Update the `global.json` to use the RTM .NET Core SDK (`preview1` is RC2, `preview2` is RTM)