### PR TITLE
Add basic appveyor manifest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: '2.124.0.{build}'
+pull_requests:
+  do_not_increment_build_number: true
+init:
+- ps: (new-object net.webclient).DownloadFile('https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-dev-win-x64.latest.exe', "c:/dotnet-install.exe")
+- ps: Start-Process c:\dotnet-install.exe -ArgumentList "/install","/quiet" -Wait
+build_script:
+- ps: dotnet restore
+- ps: dotnet build Docker.DotNet Docker.DotNet.BasicAuth Docker.DotNet.X509


### PR DESCRIPTION
This just ensures that there are no build breaks. It doesn't do any testing.