### PR TITLE
Returns container created time as DateTime

### DIFF
--- a/Docker.DotNet/Models/ContainerListResponse.Generated.cs
+++ b/Docker.DotNet/Models/ContainerListResponse.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -22,7 +23,7 @@ namespace Docker.DotNet.Models
         public string Command { get; set; }
 
         [DataMember(Name = "Created", EmitDefaultValue = false)]
-        public long Created { get; set; }
+        public DateTime Created { get; set; }
 
         [DataMember(Name = "Ports", EmitDefaultValue = false)]
         public IList<Port> Ports { get; set; }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -19,6 +19,7 @@ var typeCustomizations = map[typeCustomizationKey]CSType{
 	{reflect.TypeOf(container.RestartPolicy{}), "Name"}: {"", "RestartPolicyKind", false},
 	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:   {"", "FileSystemChangeKind", false},
 	{reflect.TypeOf(types.Image{}), "Created"}:          {"System", "DateTime", false},
+	{reflect.TypeOf(types.Container{}), "Created"}:      {"System", "DateTime", false},
 }
 
 type typeCustomizationKey struct {


### PR DESCRIPTION
Resolves: #92

Fixes a bug where container.Created was a long unix date time and converts
that to a C# System.DateTime object.