### PR TITLE
Returns container created time as DateTime

### DIFF
--- a/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
+++ b/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -43,7 +44,7 @@ namespace Docker.DotNet.Models
         public string ID { get; set; }
 
         [DataMember(Name = "Created", EmitDefaultValue = false)]
-        public string Created { get; set; }
+        public DateTime Created { get; set; }
 
         [DataMember(Name = "Path", EmitDefaultValue = false)]
         public string Path { get; set; }

--- a/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
+++ b/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -10,7 +11,7 @@ namespace Docker.DotNet.Models
         public string ID { get; set; }
 
         [DataMember(Name = "Created", EmitDefaultValue = false)]
-        public string Created { get; set; }
+        public DateTime Created { get; set; }
 
         [DataMember(Name = "Path", EmitDefaultValue = false)]
         public string Path { get; set; }

--- a/Docker.DotNet/Models/ImageHistoryResponse.Generated.cs
+++ b/Docker.DotNet/Models/ImageHistoryResponse.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -10,7 +11,7 @@ namespace Docker.DotNet.Models
         public string ID { get; set; }
 
         [DataMember(Name = "Created", EmitDefaultValue = false)]
-        public long Created { get; set; }
+        public DateTime Created { get; set; }
 
         [DataMember(Name = "CreatedBy", EmitDefaultValue = false)]
         public string CreatedBy { get; set; }

--- a/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
+++ b/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -22,7 +23,7 @@ namespace Docker.DotNet.Models
         public string Comment { get; set; }
 
         [DataMember(Name = "Created", EmitDefaultValue = false)]
-        public string Created { get; set; }
+        public DateTime Created { get; set; }
 
         [DataMember(Name = "Container", EmitDefaultValue = false)]
         public string Container { get; set; }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -16,10 +16,13 @@ import (
 )
 
 var typeCustomizations = map[typeCustomizationKey]CSType{
-	{reflect.TypeOf(container.RestartPolicy{}), "Name"}: {"", "RestartPolicyKind", false},
-	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:   {"", "FileSystemChangeKind", false},
-	{reflect.TypeOf(types.Image{}), "Created"}:          {"System", "DateTime", false},
-	{reflect.TypeOf(types.Container{}), "Created"}:      {"System", "DateTime", false},
+	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:    {"", "RestartPolicyKind", false},
+	{reflect.TypeOf(types.Container{}), "Created"}:         {"System", "DateTime", false},
+	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:      {"", "FileSystemChangeKind", false},
+	{reflect.TypeOf(types.ContainerJSONBase{}), "Created"}: {"System", "DateTime", false},
+	{reflect.TypeOf(types.Image{}), "Created"}:             {"System", "DateTime", false},
+	{reflect.TypeOf(types.ImageHistory{}), "Created"}:      {"System", "DateTime", false},
+	{reflect.TypeOf(types.ImageInspect{}), "Created"}:      {"System", "DateTime", false},
 }
 
 type typeCustomizationKey struct {


### PR DESCRIPTION
Resolves: #92

Fixes a bug where container.Created was a long unix date time and converts
that to a C# System.DateTime object.