### PR TITLE
NetStandard1.6 and Unix Socket Support

### DIFF
--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http;
-#if !NETSTANDARD1_3
+#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
 using System.Security;
 #endif
 
@@ -17,7 +17,7 @@ namespace Docker.DotNet.BasicAuth
             return new BasicAuthHandler(_username, _password, innerHandler);
         }
 
-#if !NETSTANDARD1_3
+#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
         public BasicAuthCredentials(SecureString username, SecureString password, bool isTls = false)
             : this(new MaybeSecureString(username), new MaybeSecureString(password), isTls)
         {

--- a/Docker.DotNet.BasicAuth/MaybeSecureString.cs
+++ b/Docker.DotNet.BasicAuth/MaybeSecureString.cs
@@ -1,5 +1,5 @@
 using System;
-#if !NETSTANDARD1_3
+#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
 using System.Runtime.InteropServices;
 using System.Security;
 #endif
@@ -8,7 +8,7 @@ namespace Docker.DotNet.BasicAuth
 {
     internal class MaybeSecureString : IDisposable
     {
-#if !NETSTANDARD1_3
+#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
 
         public SecureString Value { get; }
 

--- a/Docker.DotNet.BasicAuth/project.json
+++ b/Docker.DotNet.BasicAuth/project.json
@@ -13,6 +13,12 @@
     "Docker.DotNet": "2.124.2"
   },
   "frameworks": {
+    "netstandard1.6": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    },
     "netstandard1.3": {},
     "net46": {
       "frameworkAssemblies": {

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_3
+﻿#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
 using System.Net;
 #endif
 
@@ -29,7 +29,7 @@ namespace Docker.DotNet.X509
             };
 
             handler.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback;
-#if !NETSTANDARD1_3
+#if (!NETSTANDARD1_3 && !NETSTANDARD1_6)
             if (handler.ServerCertificateValidationCallback == null)
             {
                 handler.ServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;

--- a/Docker.DotNet.X509/project.json
+++ b/Docker.DotNet.X509/project.json
@@ -13,6 +13,15 @@
         "Docker.DotNet": "2.124.2"
     },
     "frameworks": {
+        "netstandard1.6": {
+            "imports": [
+                "dnxcore50",
+                "portable-net45+win8"
+            ],
+            "dependencies": {
+                "System.Security.Cryptography.X509Certificates": "4.1.0"
+            }
+        },
         "netstandard1.3": {
             "dependencies": {
                 "System.Security.Cryptography.X509Certificates": "4.1.0"

--- a/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Net.Http.Client
                 var s = new Socket(SocketType.Stream, ProtocolType.Tcp);
                 try
                 {
-#if NETSTANDARD1_3
+#if (NETSTANDARD1_3 || NETSTANDARD1_6)
                     await s.ConnectAsync(address, port).ConfigureAwait(false);
 #else
                     await Task.Factory.FromAsync(

--- a/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
@@ -1,0 +1,110 @@
+#if NETSTANDARD1_6
+
+using System;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Text;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Net.Http.Client
+{
+    internal sealed class UnixDomainSocketEndPoint : EndPoint
+    {
+        private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+        private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+
+        private static readonly int s_nativePathOffset;
+
+        private static readonly int s_nativePathLength;
+
+        private static readonly int s_nativeAddressSize;
+
+        private readonly string _path;
+
+        private readonly byte[] _encodedPath;
+
+        [DllImport("System.Native", EntryPoint = "SystemNative_GetDomainSocketSizes")]
+        internal static extern void GetDomainSocketSizes(out int pathOffset, out int pathSize, out int addressSize);
+
+        static UnixDomainSocketEndPoint()
+        {
+            GetDomainSocketSizes(out s_nativePathOffset, out s_nativePathLength, out s_nativeAddressSize);
+
+            Debug.Assert(s_nativePathOffset >= 0, "Expected path offset to be positive");
+            Debug.Assert(s_nativePathOffset + s_nativePathLength <= s_nativeAddressSize, "Expected address size to include all of the path length");
+            Debug.Assert(s_nativePathLength >= 92, "Expected max path length to be at least 92"); // per http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html
+
+            s_nativePathLength -= 1; // to account for null terminator within the allotted space
+        }
+
+        public UnixDomainSocketEndPoint(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            _path = path;
+            _encodedPath = s_pathEncoding.GetBytes(_path);
+
+            if (path.Length == 0 || _encodedPath.Length > s_nativePathLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(path), path);
+            }
+        }
+
+        internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+        {
+            if (socketAddress == null)
+            {
+                throw new ArgumentNullException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Family != EndPointAddressFamily ||
+                socketAddress.Size > s_nativeAddressSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Size > s_nativePathOffset)
+            {
+                _encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
+                for (int i = 0; i < _encodedPath.Length; i++)
+                {
+                    _encodedPath[i] = socketAddress[s_nativePathOffset + i];
+                }
+
+                _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+            }
+            else
+            {
+                _encodedPath = Array.Empty<byte>();
+                _path = string.Empty;
+            }
+        }
+
+        public override SocketAddress Serialize()
+        {
+            var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
+            Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
+
+            for (int index = 0; index < _encodedPath.Length; index++)
+            {
+                result[s_nativePathOffset + index] = _encodedPath[index];
+            }
+            result[s_nativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
+
+            return result;
+        }
+
+        public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+
+        public override AddressFamily AddressFamily => EndPointAddressFamily;
+
+        public override string ToString() => _path;
+    }
+}
+
+#endif

--- a/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-#if NETSTANDARD1_3
+#if (NETSTANDARD1_3 || NETSTANDARD1_6)
 using System.Reflection;
 #endif
 

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -9,10 +9,18 @@
     },
     "iconUrl": "https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74"
   },
-  "dependencies": {
-    "Newtonsoft.Json": "9.0.1"
-  },
+  "dependencies": {},
   "frameworks": {
+    "netstandard1.6": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.PowerShell.SDK": "1.0.0-alpha",
+        "System.Buffers": "4.0.0"
+      }
+    },
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
@@ -23,13 +31,15 @@
         "System.Net.Security": "4.0.0",
         "System.Reflection.Extensions": "4.0.1",
         "System.Reflection.TypeExtensions": "4.1.0",
-        "System.Threading.Overlapped": "4.0.1"
+        "System.Threading.Overlapped": "4.0.1",
+        "Newtonsoft.Json": "9.0.1"
       }
     },
     "net46": {
       "dependencies": {
         "System.Buffers": "4.0.0",
-        "System.Runtime": "4.0.20"
+        "System.Runtime": "4.0.20",
+        "Newtonsoft.Json": "9.0.1"
       },
       "frameworkAssemblies": {
         "System.Net.Http": "",
@@ -37,6 +47,9 @@
       }
     },
     "net45": {
+      "dependencies": {
+        "Newtonsoft.Json": "9.0.1"
+      },
       "frameworkAssemblies": {
         "System.Net.Http": "",
         "System.Runtime.Serialization": ""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.124.0.{build}'
+version: '2.124.2.{build}'
 pull_requests:
   do_not_increment_build_number: true
 init:


### PR DESCRIPTION
@jterry75 @jstarks 
This includes 3 commits, encapsulating the work for making the build work on netstarndard1.6 and adding support for unix sockets.  There is also a minor fix-up to the appveyor build version (should have been 2.124.2.{build}).