### PR TITLE
Adding unix sockets and building for netstandard1.6

### DIFF
--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http;
-#if !NETSTANDARD1_3
+#if (NET45 || NET46)
 using System.Security;
 #endif
 
@@ -17,7 +17,7 @@ namespace Docker.DotNet.BasicAuth
             return new BasicAuthHandler(_username, _password, innerHandler);
         }
 
-#if !NETSTANDARD1_3
+#if (NET45 || NET46)
         public BasicAuthCredentials(SecureString username, SecureString password, bool isTls = false)
             : this(new MaybeSecureString(username), new MaybeSecureString(password), isTls)
         {

--- a/Docker.DotNet.BasicAuth/MaybeSecureString.cs
+++ b/Docker.DotNet.BasicAuth/MaybeSecureString.cs
@@ -1,5 +1,5 @@
 using System;
-#if !NETSTANDARD1_3
+#if (NET45 || NET46)
 using System.Runtime.InteropServices;
 using System.Security;
 #endif
@@ -8,7 +8,7 @@ namespace Docker.DotNet.BasicAuth
 {
     internal class MaybeSecureString : IDisposable
     {
-#if !NETSTANDARD1_3
+#if (NET45 || NET46)
 
         public SecureString Value { get; }
 

--- a/Docker.DotNet.BasicAuth/project.json
+++ b/Docker.DotNet.BasicAuth/project.json
@@ -13,6 +13,7 @@
     "Docker.DotNet": "2.124.2"
   },
   "frameworks": {
+    "netstandard1.6": {},
     "netstandard1.3": {},
     "net46": {
       "frameworkAssemblies": {

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_3
+﻿#if (NET45 || NET46)
 using System.Net;
 #endif
 
@@ -29,7 +29,7 @@ namespace Docker.DotNet.X509
             };
 
             handler.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback;
-#if !NETSTANDARD1_3
+#if (NET45 || NET46)
             if (handler.ServerCertificateValidationCallback == null)
             {
                 handler.ServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;

--- a/Docker.DotNet.X509/project.json
+++ b/Docker.DotNet.X509/project.json
@@ -13,6 +13,11 @@
         "Docker.DotNet": "2.124.2"
     },
     "frameworks": {
+        "netstandard1.6": {
+            "dependencies": {
+                "System.Security.Cryptography.X509Certificates": "4.1.0"
+            }
+        },
         "netstandard1.3": {
             "dependencies": {
                 "System.Security.Cryptography.X509Certificates": "4.1.0"

--- a/Docker.DotNet/Microsoft.Net.Http.Client/LICENSE-MIT.txt
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/LICENSE-MIT.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Net.Http.Client
                 var s = new Socket(SocketType.Stream, ProtocolType.Tcp);
                 try
                 {
-#if NETSTANDARD1_3
+#if (NETSTANDARD1_3 || NETSTANDARD1_6)
                     await s.ConnectAsync(address, port).ConfigureAwait(false);
 #else
                     await Task.Factory.FromAsync(

--- a/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE-MIT.txt file for more information.
+
+#if NETSTANDARD1_6
+
+using System;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Text;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Net.Http.Client
+{
+    internal sealed class UnixDomainSocketEndPoint : EndPoint
+    {
+        private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+        private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+
+        private static readonly int s_nativePathOffset = 2; // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
+
+        private static readonly int s_nativePathLength = 91; // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html, -1 for terminator
+
+        private static readonly int s_nativeAddressSize = s_nativePathOffset + s_nativePathLength;
+
+        private readonly string _path;
+
+        private readonly byte[] _encodedPath;
+
+        public UnixDomainSocketEndPoint(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            _path = path;
+            _encodedPath = s_pathEncoding.GetBytes(_path);
+
+            if (path.Length == 0 || _encodedPath.Length > s_nativePathLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(path), path);
+            }
+        }
+
+        internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+        {
+            if (socketAddress == null)
+            {
+                throw new ArgumentNullException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Family != EndPointAddressFamily ||
+                socketAddress.Size > s_nativeAddressSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(socketAddress));
+            }
+
+            if (socketAddress.Size > s_nativePathOffset)
+            {
+                _encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
+                for (int i = 0; i < _encodedPath.Length; i++)
+                {
+                    _encodedPath[i] = socketAddress[s_nativePathOffset + i];
+                }
+
+                _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+            }
+            else
+            {
+                _encodedPath = Array.Empty<byte>();
+                _path = string.Empty;
+            }
+        }
+
+        public override SocketAddress Serialize()
+        {
+            var result = new SocketAddress(AddressFamily.Unix, s_nativeAddressSize);
+            Debug.Assert(_encodedPath.Length + s_nativePathOffset <= result.Size, "Expected path to fit in address");
+
+            for (int index = 0; index < _encodedPath.Length; index++)
+            {
+                result[s_nativePathOffset + index] = _encodedPath[index];
+            }
+            result[s_nativePathOffset + _encodedPath.Length] = 0; // path must be null-terminated
+
+            return result;
+        }
+
+        public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+
+        public override AddressFamily AddressFamily => EndPointAddressFamily;
+
+        public override string ToString() => _path;
+    }
+}
+
+#endif

--- a/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-#if NETSTANDARD1_3
+#if (NETSTANDARD1_3 || NETSTANDARD1_6)
 using System.Reflection;
 #endif
 

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -13,6 +13,19 @@
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
+    "netstandard1.6": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Buffers": "4.0.0",
+        "System.IO.Pipes": "4.0.0",
+        "System.Net.NameResolution": "4.0.0",
+        "System.Net.Requests": "4.0.11",
+        "System.Net.Security": "4.0.0",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Threading.Overlapped": "4.0.1"
+      }
+    },
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.124.0.{build}'
+version: '2.124.2.{build}'
 pull_requests:
   do_not_increment_build_number: true
 init:


### PR DESCRIPTION
@jterry75 @jstarks 
These changes prepare the build to work against netstandard1.6, including formatting updates for project.json.
They also introduce unix socket support for connections when running directly on Linux.