### PR TITLE
Minor code cleanup.

### DIFF
--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -11,7 +11,7 @@ namespace Docker.DotNet.X509
 {
     public class CertificateCredentials : Credentials
     {
-        private X509Certificate2 _certificate;
+        private readonly X509Certificate2 _certificate;
 
         public CertificateCredentials(X509Certificate2 clientCertificate)
         {

--- a/Docker.DotNet/BinaryRequestContent.cs
+++ b/Docker.DotNet/BinaryRequestContent.cs
@@ -7,9 +7,8 @@ namespace Docker.DotNet
 {
     internal class BinaryRequestContent : IRequestContent
     {
-        private Stream Stream { get; set; }
-
-        private string MimeType { get; set; }
+        private readonly Stream _stream;
+        private readonly string _mimeType;
 
         public BinaryRequestContent(Stream stream, string mimeType)
         {
@@ -23,14 +22,14 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(mimeType));
             }
 
-            this.Stream = stream;
-            this.MimeType = mimeType;
+            this._stream = stream;
+            this._mimeType = mimeType;
         }
 
         public HttpContent GetContent()
         {
-            StreamContent data = new StreamContent(this.Stream);
-            data.Headers.ContentType = new MediaTypeHeaderValue(this.MimeType);
+            var data = new StreamContent(this._stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue(this._mimeType);
             return data;
         }
     }

--- a/Docker.DotNet/BoolQueryStringConverter.cs
+++ b/Docker.DotNet/BoolQueryStringConverter.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Diagnostics;
-using System.Globalization;
-
-namespace Docker.DotNet.Models
+﻿namespace Docker.DotNet
 {
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+
     internal class BoolQueryStringConverter : IQueryStringConverter
     {
         public bool CanConvert(Type t)

--- a/Docker.DotNet/DockerApiException.cs
+++ b/Docker.DotNet/DockerApiException.cs
@@ -10,7 +10,7 @@ namespace Docker.DotNet
         public string ResponseBody { get; private set; }
 
         public DockerApiException(HttpStatusCode statusCode, string responseBody)
-            : base(string.Format("Docker API responded with status code={0}, response={1}", statusCode, responseBody))
+            : base($"Docker API responded with status code={statusCode}, response={responseBody}")
         {
             this.StatusCode = statusCode;
             this.ResponseBody = responseBody;

--- a/Docker.DotNet/DockerPipeStream.cs
+++ b/Docker.DotNet/DockerPipeStream.cs
@@ -5,14 +5,13 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Net.Http.Client;
-using Microsoft.Win32.SafeHandles;
 
 namespace Docker.DotNet
 {
     internal class DockerPipeStream : WriteClosableStream
     {
-        private PipeStream _stream;
-        private EventWaitHandle _event = new EventWaitHandle(false, EventResetMode.AutoReset);
+        private readonly PipeStream _stream;
+        private readonly EventWaitHandle _event = new EventWaitHandle(false, EventResetMode.AutoReset);
 
         public DockerPipeStream(PipeStream stream)
         {
@@ -50,11 +49,10 @@ namespace Docker.DotNet
             // The Docker daemon expects a write of zero bytes to signal the end of writes. Use native
             // calls to achieve this since CoreCLR ignores a zero-byte write.
             var overlapped = new NativeOverlapped();
-            SafeWaitHandle handle;
 #if NET45
-            handle = _event.SafeWaitHandle;
+            var handle = _event.SafeWaitHandle;
 #else
-            handle = _event.GetSafeWaitHandle();
+            var handle = _event.GetSafeWaitHandle();
 #endif
             // Set the low bit to tell Windows not to send the result of this IO to the
             // completion port.

--- a/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -21,11 +21,11 @@ namespace Docker.DotNet
             }
         };
 
-        private DockerClient Client { get; set; }
+        private readonly DockerClient _client;
 
         internal ContainerOperations(DockerClient client)
         {
-            this.Client = client;
+            this._client = client;
         }
 
         public async Task<IList<ContainerListResponse>> ListContainersAsync(ContainersListParameters parameters)
@@ -35,10 +35,9 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = "containers/json";
             IQueryString queryParameters = new QueryString<ContainersListParameters>(parameters);
-            var response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerListResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "containers/json", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerListResponse[]>(response.Body);
         }
 
         public async Task<ContainerInspectResponse> InspectContainerAsync(string id)
@@ -48,9 +47,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/json";
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerInspectResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/json", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerInspectResponse>(response.Body);
         }
 
         public async Task<CreateContainerResponse> CreateContainerAsync(CreateContainerParameters parameters)
@@ -67,10 +65,9 @@ namespace Docker.DotNet
                 qs = new QueryString<CreateContainerParameters>(parameters);
             }
 
-            var path = "containers/create";
-            var data = new JsonRequestContent<CreateContainerParameters>(parameters, this.Client.JsonSerializer);
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, qs, data).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<CreateContainerResponse>(response.Body);
+            var data = new JsonRequestContent<CreateContainerParameters>(parameters, this._client.JsonSerializer);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, "containers/create", qs, data).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<CreateContainerResponse>(response.Body);
         }
 
         public Task<Stream> ExportContainerAsync(string id, CancellationToken cancellationToken)
@@ -80,8 +77,7 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/export";
-            return this.Client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null, null, null, cancellationToken);
+            return this._client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/export", null, null, null, cancellationToken);
         }
 
         public async Task<ContainerProcessesResponse> ListProcessesAsync(string id, ContainerListProcessesParameters parameters)
@@ -96,10 +92,9 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/top";
             IQueryString queryParameters = new QueryString<ContainerListProcessesParameters>(parameters);
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerProcessesResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/top", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerProcessesResponse>(response.Body);
         }
 
         public async Task<IList<ContainerFileSystemChangeResponse>> InspectChangesAsync(string id)
@@ -109,9 +104,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/changes";
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerFileSystemChangeResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/changes", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerFileSystemChangeResponse[]>(response.Body);
         }
 
         public async Task<bool> StartContainerAsync(string id, HostConfig hostConfig)
@@ -121,13 +115,12 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/start";
             JsonRequestContent<HostConfig> data = null;
             if (hostConfig != null)
             {
-                data = new JsonRequestContent<HostConfig>(hostConfig, this.Client.JsonSerializer);
+                data = new JsonRequestContent<HostConfig>(hostConfig, this._client.JsonSerializer);
             }
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data).ConfigureAwait(false);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/start", null, data).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -143,10 +136,9 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/exec";
-            var data = new JsonRequestContent<ContainerExecCreateParameters>(parameters, this.Client.JsonSerializer);
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerExecCreateResponse>(response.Body);
+            var data = new JsonRequestContent<ContainerExecCreateParameters>(parameters, this._client.JsonSerializer);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/exec", null, data).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerExecCreateResponse>(response.Body);
         }
 
         public async Task<bool> StopContainerAsync(string id, ContainerStopParameters parameters, CancellationToken cancellationToken)
@@ -161,11 +153,10 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/stop";
             IQueryString queryParameters = new QueryString<ContainerStopParameters>(parameters);
             // since specified wait timespan can be greater than HttpClient's default, we set the
             // client timeout to infinite and provide a cancellation token.
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/stop", queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -182,11 +173,10 @@ namespace Docker.DotNet
             }
 
 
-            var path = $"containers/{id}/restart";
             IQueryString queryParameters = new QueryString<ConatinerRestartParameters>(parameters);
             // since specified wait timespan can be greater than HttpClient's default, we set the
             // client timeout to infinite and provide a cancellation token.
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, new TimeSpan?(new TimeSpan(Timeout.Infinite)), cancellationToken);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/restart", queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken);
         }
 
         public Task KillContainerAsync(string id, ContainerKillParameters parameters)
@@ -201,9 +191,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/kill";
             IQueryString queryParameters = new QueryString<ContainerKillParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/kill", queryParameters);
         }
 
         public Task PauseContainerAsync(string id)
@@ -213,8 +202,7 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/pause";
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/pause", null);
         }
 
         public Task UnpauseContainerAsync(string id)
@@ -224,8 +212,7 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/unpause";
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/unpause", null);
         }
 
         public async Task<ContainerWaitResponse> WaitContainerAsync(string id, CancellationToken cancellationToken)
@@ -235,9 +222,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"containers/{id}/wait";
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerWaitResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/wait", null, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerWaitResponse>(response.Body);
         }
 
         public Task RemoveContainerAsync(string id, ContainerRemoveParameters parameters)
@@ -252,9 +238,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}";
             IQueryString queryParameters = new QueryString<ContainerRemoveParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Delete, path, queryParameters);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Delete, $"containers/{id}", queryParameters);
         }
 
         public Task<Stream> GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken)
@@ -269,9 +254,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/logs";
             IQueryString queryParameters = new QueryString<ContainerLogsParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, queryParameters, null, cancellationToken);
+            return this._client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/logs", queryParameters, null, cancellationToken);
         }
 
         public async Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statOnly, CancellationToken cancellationToken)
@@ -288,9 +272,8 @@ namespace Docker.DotNet
 
             IQueryString queryParameters = new QueryString<GetArchiveFromContainerParameters>(parameters);
 
-            var path = $"containers/{id}/archive";
 
-            var response = await this.Client.MakeRequestForStreamedResponseAsync(new[] { NoSuchContainerHandler }, statOnly ? HttpMethod.Head : HttpMethod.Get, path, queryParameters, null, cancellationToken);
+            var response = await this._client.MakeRequestForStreamedResponseAsync(new[] { NoSuchContainerHandler }, statOnly ? HttpMethod.Head : HttpMethod.Get, $"containers/{id}/archive", queryParameters, null, cancellationToken);
 
             var statHeader = response.Headers.GetValues("X-Docker-Container-Path-Stat").First();
 
@@ -298,7 +281,7 @@ namespace Docker.DotNet
 
             var stat = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 
-            var pathStat = this.Client.JsonSerializer.DeserializeObject<ContainerPathStatResponse>(stat);
+            var pathStat = this._client.JsonSerializer.DeserializeObject<ContainerPathStatResponse>(stat);
 
             return new GetArchiveFromContainerResponse
             {
@@ -322,10 +305,7 @@ namespace Docker.DotNet
             IQueryString queryParameters = new QueryString<ContainerPathStatParameters>(parameters);
 
             var data = new BinaryRequestContent(stream, "application/x-tar");
-
-            var path = $"containers/{id}/archive";
-
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Put, path, queryParameters, data, null, cancellationToken);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Put, $"containers/{id}/archive", queryParameters, data, null, cancellationToken);
         }
 
         public async Task<MultiplexedStream> AttachContainerAsync(string id, bool tty, ContainerAttachParameters parameters, CancellationToken cancellationToken)
@@ -340,9 +320,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/attach";
             var queryParameters = new QueryString<ContainerAttachParameters>(parameters);
-            var stream = await this.Client.MakeRequestForHijackedStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, null, cancellationToken).ConfigureAwait(false);
+            var stream = await this._client.MakeRequestForHijackedStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/attach", queryParameters, null, null, cancellationToken).ConfigureAwait(false);
             if (!stream.CanCloseWrite)
             {
                 stream.Dispose();
@@ -364,9 +343,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"containers/{id}/resize";
             var queryParameters = new QueryString<ContainerResizeParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, null, cancellationToken);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/resize", queryParameters, null, null, cancellationToken);
         }
 
         // StartContainerExecAsync will start the process specified by id in detach mode with no connected
@@ -378,13 +356,12 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"exec/{id}/start";
             var parameters = new ContainerExecStartParameters
             {
                 Detach = true,
             };
-            var data = new JsonRequestContent<ContainerExecStartParameters>(parameters, this.Client.JsonSerializer);
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data, null, cancellationToken);
+            var data = new JsonRequestContent<ContainerExecStartParameters>(parameters, this._client.JsonSerializer);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"exec/{id}/start", null, data, null, cancellationToken);
         }
 
         // StartAndAttachContainerExecAsync will start the process specified by id with stdin, stdout, stderr
@@ -401,9 +378,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"exec/{id}/start";
-            var data = new JsonRequestContent<ContainerExecStartParameters>(new ContainerExecStartParameters(eConfig), this.Client.JsonSerializer);
-            var stream = await this.Client.MakeRequestForHijackedStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, null, data, cancellationToken).ConfigureAwait(false);
+            var data = new JsonRequestContent<ContainerExecStartParameters>(new ContainerExecStartParameters(eConfig), this._client.JsonSerializer);
+            var stream = await this._client.MakeRequestForHijackedStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"exec/{id}/start", null, null, data, cancellationToken).ConfigureAwait(false);
             if (!stream.CanCloseWrite)
             {
                 stream.Dispose();
@@ -420,9 +396,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"exec/{id}/json";
-            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null, null, null, cancellationToken).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ContainerExecInspectResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"exec/{id}/json", null, null, null, cancellationToken).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ContainerExecInspectResponse>(response.Body);
         }
 
         public Task ResizeContainerExecTtyAsync(string id, ContainerResizeParameters parameters, CancellationToken cancellationToken)
@@ -437,9 +412,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"exec/{id}/resize";
             var queryParameters = new QueryString<ContainerResizeParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, null, cancellationToken);
+            return this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"exec/{id}/resize", queryParameters, null, null, cancellationToken);
         }
     }
 }

--- a/Docker.DotNet/Endpoints/ImageOperations.cs
+++ b/Docker.DotNet/Endpoints/ImageOperations.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -23,48 +22,45 @@ namespace Docker.DotNet
 
         private const string RegistryAuthHeaderKey = "X-Registry-Auth";
 
-        private DockerClient Client { get; set; }
+        private readonly DockerClient _client;
 
         internal ImageOperations(DockerClient client)
         {
-            this.Client = client;
+            this._client = client;
         }
 
         public async Task<IList<ImagesListResponse>> ListImagesAsync(ImagesListParameters parameters)
         {
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = "images/json";
             IQueryString queryParameters = new QueryString<ImagesListParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ImagesListResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "images/json", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ImagesListResponse[]>(response.Body);
         }
 
         public async Task<ImageInspectResponse> InspectImageAsync(string name)
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
-            string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/json", name);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ImageInspectResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Get, $"images/{name}/json", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ImageInspectResponse>(response.Body);
         }
 
         public async Task<IList<ImageHistoryResponse>> GetImageHistoryAsync(string name)
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
-            string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/history", name);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ImageHistoryResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Get, $"images/{name}/history", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ImageHistoryResponse[]>(response.Body);
         }
 
 
@@ -72,55 +68,52 @@ namespace Docker.DotNet
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/tag", name);
             IQueryString queryParameters = new QueryString<ImageTagParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Post, path, queryParameters);
+            return this._client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Post, $"images/{name}/tag", queryParameters);
         }
 
         public async Task<IList<IDictionary<string, string>>> DeleteImageAsync(string name, ImageDeleteParameters parameters)
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = string.Format(CultureInfo.InvariantCulture, "images/{0}", name);
             IQueryString queryParameters = new QueryString<ImageDeleteParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Delete, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<Dictionary<string, string>[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Delete, $"images/{name}", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<Dictionary<string, string>[]>(response.Body);
         }
 
         public async Task<IList<ImageSearchResponse>> SearchImagesAsync(ImagesSearchParameters parameters)
         {
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = "images/search";
             IQueryString queryParameters = new QueryString<ImagesSearchParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<ImageSearchResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "images/search", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<ImageSearchResponse[]>(response.Body);
         }
 
         public Task<Stream> CreateImageAsync(ImagesCreateParameters parameters, AuthConfig authConfig)
         {
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             return PullImageAsync(new ImagesPullParameters() { All = false, Parent = parameters.Parent, RegistryAuth = parameters.RegistryAuth }, authConfig);
@@ -130,29 +123,27 @@ namespace Docker.DotNet
         {
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = "images/create";
             IQueryString queryParameters = new QueryString<ImagesPullParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(this.Client.NoErrorHandlers, HttpMethod.Post, path, queryParameters, RegistryAuthHeaders(authConfig), null, CancellationToken.None);
+            return this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Post, "images/create", queryParameters, RegistryAuthHeaders(authConfig), null, CancellationToken.None);
         }
 
         public Task<Stream> PushImageAsync(string name, ImagePushParameters parameters, AuthConfig authConfig)
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
-            string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/push", name);
             IQueryString queryParameters = new QueryString<ImagePushParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(this.Client.NoErrorHandlers, HttpMethod.Post, path, queryParameters, RegistryAuthHeaders(authConfig), null, CancellationToken.None);
+            return this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Post, $"images/{name}/push", queryParameters, RegistryAuthHeaders(authConfig), null, CancellationToken.None);
         }
 
         private Dictionary<string, string> RegistryAuthHeaders(AuthConfig authConfig)
@@ -161,7 +152,7 @@ namespace Docker.DotNet
             {
                 {
                     RegistryAuthHeaderKey,
-                    Convert.ToBase64String(Encoding.UTF8.GetBytes(this.Client.JsonSerializer.SerializeObject(authConfig ?? new AuthConfig())))
+                    Convert.ToBase64String(Encoding.UTF8.GetBytes(this._client.JsonSerializer.SerializeObject(authConfig ?? new AuthConfig())))
                 }
             };
         }

--- a/Docker.DotNet/Endpoints/MiscellaneousOperations.cs
+++ b/Docker.DotNet/Endpoints/MiscellaneousOperations.cs
@@ -9,11 +9,11 @@ namespace Docker.DotNet
 {
     internal class MiscellaneousOperations : IMiscellaneousOperations
     {
-        private DockerClient Client { get; set; }
+        private readonly DockerClient _client;
 
         internal MiscellaneousOperations(DockerClient client)
         {
-            this.Client = client;
+            this._client = client;
         }
 
         public Task AuthenticateAsync(AuthConfig authConfig)
@@ -22,26 +22,26 @@ namespace Docker.DotNet
             {
                 throw new ArgumentNullException(nameof(authConfig));
             }
-            var data = new JsonRequestContent<AuthConfig>(authConfig, this.Client.JsonSerializer);
+            var data = new JsonRequestContent<AuthConfig>(authConfig, this._client.JsonSerializer);
 
-            return this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Post, "auth", null, data);
+            return this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Post, "auth", null, data);
         }
 
         public async Task<VersionResponse> GetVersionAsync()
         {
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, "version", null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<VersionResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "version", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<VersionResponse>(response.Body);
         }
 
         public Task PingAsync()
         {
-            return this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, "_ping", null);
+            return this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "_ping", null);
         }
 
         public async Task<SystemInfoResponse> GetSystemInfoAsync()
         {
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, "info", null).ConfigureAwait(false); ;
-            return this.Client.JsonSerializer.DeserializeObject<SystemInfoResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "info", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<SystemInfoResponse>(response.Body);
         }
 
         public Task<Stream> MonitorEventsAsync(ContainerEventsParameters parameters, CancellationToken cancellationToken)
@@ -52,7 +52,7 @@ namespace Docker.DotNet
             }
 
             IQueryString queryParameters = new QueryString<ContainerEventsParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(this.Client.NoErrorHandlers, HttpMethod.Get, "events", queryParameters, null, cancellationToken);
+            return this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Get, "events", queryParameters, null, cancellationToken);
         }
 
         public async Task<CommitContainerChangesResponse> CommitContainerChangesAsync(CommitContainerChangesParameters parameters)
@@ -62,11 +62,11 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            JsonRequestContent<Config> data = parameters.Config == null ? null : new JsonRequestContent<Config>(parameters.Config, this.Client.JsonSerializer);
+            var data = parameters.Config == null ? null : new JsonRequestContent<Config>(parameters.Config, this._client.JsonSerializer);
 
             IQueryString queryParameters = new QueryString<CommitContainerChangesParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Post, "commit", queryParameters, data).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<CommitContainerChangesResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Post, "commit", queryParameters, data).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<CommitContainerChangesResponse>(response.Body);
         }
 
         public Task<Stream> GetImageAsTarballAsync(string name, CancellationToken cancellationToken)
@@ -83,7 +83,7 @@ namespace Docker.DotNet
                 queryString = new EnumerableQueryString("names", names);
             }
 
-            return this.Client.MakeRequestForStreamAsync(new[] { ImageOperations.NoSuchImageHandler }, HttpMethod.Get, "images/get", queryString, null, cancellationToken);
+            return this._client.MakeRequestForStreamAsync(new[] { ImageOperations.NoSuchImageHandler }, HttpMethod.Get, "images/get", queryString, null, cancellationToken);
         }
 
         public Task LoadImageFromTarballAsync(Stream stream, CancellationToken cancellationToken)
@@ -99,8 +99,8 @@ namespace Docker.DotNet
             }
 
             IQueryString queryParameters = new QueryString<ImageLoadParameters>(parameters ?? new ImageLoadParameters());
-            BinaryRequestContent data = new BinaryRequestContent(stream, "application/x-tar");
-            return this.Client.MakeRequestForStreamAsync(new[] { ImageOperations.NoSuchImageHandler }, HttpMethod.Post, "images/load", queryParameters, data, cancellationToken);
+            var data = new BinaryRequestContent(stream, "application/x-tar");
+            return this._client.MakeRequestForStreamAsync(new[] { ImageOperations.NoSuchImageHandler }, HttpMethod.Post, "images/load", queryParameters, data, cancellationToken);
         }
 
         public Task<Stream> BuildImageFromDockerfileAsync(Stream contents, ImageBuildParameters parameters, CancellationToken cancellationToken)
@@ -115,9 +115,9 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            BinaryRequestContent data = new BinaryRequestContent(contents, "application/tar");
+            var data = new BinaryRequestContent(contents, "application/tar");
             IQueryString queryParameters = new QueryString<ImageBuildParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(this.Client.NoErrorHandlers, HttpMethod.Post, "build", queryParameters, data, cancellationToken);
+            return this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Post, "build", queryParameters, data, cancellationToken);
         }
     }
 }

--- a/Docker.DotNet/Endpoints/NetworkOperations.cs
+++ b/Docker.DotNet/Endpoints/NetworkOperations.cs
@@ -18,11 +18,11 @@ namespace Docker.DotNet
             }
         };
 
-        private DockerClient Client { get; set; }
+        private readonly DockerClient _client;
 
         internal NetworkOperations(DockerClient client)
         {
-            this.Client = client;
+            this._client = client;
         }
 
         public Task ConnectNetworkAsync(string id, NetworkConnectParameters parameters)
@@ -37,9 +37,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"networks/{id}/connect";
-            var data = new JsonRequestContent<NetworkConnectParameters>(parameters, this.Client.JsonSerializer);
-            return this.Client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, path, null, data);
+            var data = new JsonRequestContent<NetworkConnectParameters>(parameters, this._client.JsonSerializer);
+            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, $"networks/{id}/connect", null, data);
         }
 
         public async Task<NetworksCreateResponse> CreateNetworkAsync(NetworksCreateParameters parameters)
@@ -49,10 +48,9 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = "networks/create";
-            var data = new JsonRequestContent<NetworksCreateParameters>(parameters, this.Client.JsonSerializer);
-            var response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Post, path, null, data).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<NetworksCreateResponse>(response.Body);
+            var data = new JsonRequestContent<NetworksCreateParameters>(parameters, this._client.JsonSerializer);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Post, "networks/create", null, data).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<NetworksCreateResponse>(response.Body);
         }
 
         public Task DeleteNetworkAsync(string id)
@@ -62,8 +60,7 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"networks/{id}";
-            return this.Client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Delete, path, null);
+            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Delete, $"networks/{id}", null);
         }
 
         public Task DisconnectNetworkAsync(string id, NetworkDisconnectParameters parameters)
@@ -78,9 +75,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            var path = $"networks/{id}/disconnect";
-            var data = new JsonRequestContent<NetworkDisconnectParameters>(parameters, this.Client.JsonSerializer);
-            return this.Client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, path, null, data);
+            var data = new JsonRequestContent<NetworkDisconnectParameters>(parameters, this._client.JsonSerializer);
+            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, $"networks/{id}/disconnect", null, data);
         }
 
         public async Task<NetworkResponse> InspectNetworkAsync(string id)
@@ -90,17 +86,15 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(id));
             }
 
-            var path = $"networks/{id}";
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchNetworkHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<NetworkResponse>(response.Body);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, $"networks/{id}", null).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<NetworkResponse>(response.Body);
         }
 
         public async Task<IList<NetworkListResponse>> ListNetworksAsync(NetworksListParameters parameters)
         {
-            var path = "networks";
             var queryParameters = parameters == null ? null : new QueryString<NetworksListParameters>(parameters);
-            var response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
-            return this.Client.JsonSerializer.DeserializeObject<NetworkListResponse[]>(response.Body);
+            var response = await this._client.MakeRequestAsync(this._client.NoErrorHandlers, HttpMethod.Get, "networks", queryParameters).ConfigureAwait(false);
+            return this._client.JsonSerializer.DeserializeObject<NetworkListResponse[]>(response.Body);
         }
     }
 }

--- a/Docker.DotNet/HttpUtility.cs
+++ b/Docker.DotNet/HttpUtility.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 
 namespace Docker.DotNet
 {
@@ -12,11 +11,11 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(baseUri));
             }
 
-            UriBuilder builder = new UriBuilder(baseUri);
+            var builder = new UriBuilder(baseUri);
 
             if (requestedApiVersion != null)
             {
-                builder.Path += string.Format(CultureInfo.InvariantCulture, "v{0}/", requestedApiVersion);
+                builder.Path += $"v{requestedApiVersion}/";
             }
 
             if (!string.IsNullOrEmpty(path))

--- a/Docker.DotNet/JsonIso8601AndUnixEpochDateConverter.cs
+++ b/Docker.DotNet/JsonIso8601AndUnixEpochDateConverter.cs
@@ -22,8 +22,8 @@ namespace Docker.DotNet
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            bool isNullableType = (objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() == typeof (Nullable<>));
-            object value = reader.Value;
+            var isNullableType = (objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() == typeof (Nullable<>));
+            var value = reader.Value;
 
             DateTime result;
             if (value is DateTime)
@@ -42,7 +42,7 @@ namespace Docker.DotNet
             }
             else
             {
-                throw new NotImplementedException(string.Format(CultureInfo.InvariantCulture, "Deserializing {0} back to {1} is not handled.", value.GetType().FullName, objectType.FullName));
+                throw new NotImplementedException($"Deserializing {value.GetType().FullName} back to {objectType.FullName} is not handled.");
             }
 
             if (isNullableType && result == default(DateTime))

--- a/Docker.DotNet/JsonRequestContent.cs
+++ b/Docker.DotNet/JsonRequestContent.cs
@@ -9,9 +9,8 @@ namespace Docker.DotNet
     {
         private const string JsonMimeType = "application/json";
 
-        private T Value { get; set; }
-
-        private JsonSerializer Serializer { get; set; }
+        private readonly T _value;
+        private readonly JsonSerializer _serializer;
 
         public JsonRequestContent(T val, JsonSerializer serializer)
         {
@@ -25,13 +24,13 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(serializer));
             }
 
-            this.Value = val;
-            this.Serializer = serializer;
+            this._value = val;
+            this._serializer = serializer;
         }
 
         public HttpContent GetContent()
         {
-            string serializedObject = this.Serializer.SerializeObject(this.Value);
+            var serializedObject = this._serializer.SerializeObject(this._value);
             return new StringContent(serializedObject, Encoding.UTF8, JsonMimeType);
         }
     }

--- a/Docker.DotNet/JsonVersionConverter.cs
+++ b/Docker.DotNet/JsonVersionConverter.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Docker.DotNet
 {
-    internal class JsonVersionConverter : Newtonsoft.Json.JsonConverter
+    internal class JsonVersionConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
         {
@@ -13,11 +12,11 @@ namespace Docker.DotNet
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            string strVal = reader.Value as string;
+            var strVal = reader.Value as string;
             if (strVal == null)
             {
                 var valueType = reader.Value == null ? "<null>" : reader.Value.GetType().FullName;
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Cannot deserialize value of type '{0}' to '{1}' ", valueType, objectType.FullName));
+                throw new InvalidOperationException($"Cannot deserialize value of type '{valueType}' to '{objectType.FullName}' ");
             }
 
             return Version.Parse(strVal);

--- a/Docker.DotNet/QueryString.cs
+++ b/Docker.DotNet/QueryString.cs
@@ -27,12 +27,12 @@ namespace Docker.DotNet
 
         public IDictionary<string, string[]> GetKeyValuePairs()
         {
-            Dictionary<string, string[]> queryParameters = new Dictionary<string, string[]>();
+            var queryParameters = new Dictionary<string, string[]>();
             foreach (var pair in this.AttributedPublicProperties)
             {
-                PropertyInfo property = pair.Item1;
-                QueryStringParameterAttribute attribute = pair.Item2;
-                object value = property.GetValue(this.Object, null);
+                var property = pair.Item1;
+                var attribute = pair.Item2;
+                var value = property.GetValue(this.Object, null);
 
                 // 'Required' check
                 if (attribute.IsRequired && value == null)
@@ -44,7 +44,7 @@ namespace Docker.DotNet
                 // Serialize
                 if (attribute.IsRequired || !IsDefaultOfType(value))
                 {
-                    string keyStr = attribute.Name;
+                    var keyStr = attribute.Name;
                     string[] valueStr;
                     if (attribute.ConverterType == null)
                     {
@@ -52,7 +52,7 @@ namespace Docker.DotNet
                     }
                     else
                     {
-                        IQueryStringConverter converter = this.QueryStringConverterInstanceFactory.GetConverterInstance(attribute.ConverterType);
+                        var converter = this.QueryStringConverterInstanceFactory.GetConverterInstance(attribute.ConverterType);
                         valueStr = this.ConvertValue(converter, value);
 
                         if (valueStr == null)
@@ -93,17 +93,17 @@ namespace Docker.DotNet
 
         private Tuple<PropertyInfo, TAttribType>[] FindAttributedPublicProperties<TValue, TAttribType>() where TAttribType : Attribute
         {
-            Type t = typeof(TValue);
-            Type ofAttributeType = typeof(TAttribType);
+            var t = typeof(TValue);
+            var ofAttributeType = typeof(TAttribType);
 
-            PropertyInfo[] properties = t.GetProperties();
-            IEnumerable<PropertyInfo> publicProperties = properties.Where(p => p.GetGetMethod(false).IsPublic);
+            var properties = t.GetProperties();
+            var publicProperties = properties.Where(p => p.GetGetMethod(false).IsPublic);
             if (!publicProperties.Any())
             {
                 throw new InvalidOperationException($"No public property getters found on type {t.FullName}.");
             }
 
-            PropertyInfo[] attributedPublicProperties = properties.Where(p => p.GetCustomAttribute<TAttribType>() != null).ToArray();
+            var attributedPublicProperties = properties.Where(p => p.GetCustomAttribute<TAttribType>() != null).ToArray();
             if (!attributedPublicProperties.Any())
             {
                 throw new InvalidOperationException(

--- a/Docker.DotNet/QueryStringConverterInstanceFactory.cs
+++ b/Docker.DotNet/QueryStringConverterInstanceFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace Docker.DotNet
 {
@@ -15,7 +14,7 @@ namespace Docker.DotNet
 
         public IQueryStringConverter GetConverterInstance(Type t)
         {
-            IQueryStringConverter cached = GetCachedInstance(t);
+            var cached = GetCachedInstance(t);
             if (cached != null)
             {
                 return cached;
@@ -34,7 +33,7 @@ namespace Docker.DotNet
             var instance = Activator.CreateInstance(t) as IQueryStringConverter;
             if (instance == null)
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Could not get instance of {0}", t.FullName));
+                throw new InvalidOperationException($"Could not get instance of {t.FullName}");
             }
             return instance;
         }

--- a/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 #if (NETSTANDARD1_3 || NETSTANDARD1_6)
 using System.Reflection;
@@ -29,7 +28,7 @@ namespace Docker.DotNet
 
             if (converterType != null && !converterType.GetInterfaces().Contains(typeof (IQueryStringConverter)))
             {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Provided query string converter type is not {0}", typeof (IQueryStringConverter).FullName), nameof(converterType));
+                throw new ArgumentException($"Provided query string converter type is not {typeof(IQueryStringConverter).FullName}", nameof(converterType));
             }
 
             this.Name = name;


### PR DESCRIPTION
Refactors a few patterns of code design.
Removes redundant assignments.
Replaces string.Format with string interpolation.
Uses var or strong declaration.
Inline's path strings to avoid temporary assignment.