### PR TITLE
Add the 'Logs' parameter to the Attach operation's model.

### DIFF
--- a/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -19,5 +19,8 @@ namespace Docker.DotNet.Models
 
         [QueryStringParameter("detachKeys", false)]
         public string DetachKeys { get; set; }
+
+        [QueryStringParameter("logs", false, typeof(BoolQueryStringConverter))]
+        public bool? Logs { get; set; }
     }
 }


### PR DESCRIPTION
Added the "logs" parameter to the Attach command.

    logs – 1/True/true or 0/False/false, return logs. Default false.

https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/attach-to-a-container