### PR TITLE
Updates Models to release v1.12.0

### DIFF
--- a/Docker.DotNet/Models/Annotations.Generated.cs
+++ b/Docker.DotNet/Models/Annotations.Generated.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Annotations // (swarm.Annotations)
+    {
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Labels", EmitDefaultValue = false)]
+        public IDictionary<string, string> Labels { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/CAConfig.Generated.cs
+++ b/Docker.DotNet/Models/CAConfig.Generated.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class CAConfig // (swarm.CAConfig)
+    {
+        [DataMember(Name = "NodeCertExpiry", EmitDefaultValue = false)]
+        public long NodeCertExpiry { get; set; }
+
+        [DataMember(Name = "ExternalCAs", EmitDefaultValue = false)]
+        public IList<ExternalCA> ExternalCAs { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/ClusterInfo.Generated.cs
+++ b/Docker.DotNet/Models/ClusterInfo.Generated.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class ClusterInfo // (swarm.ClusterInfo)
+    {
+        public ClusterInfo()
+        {
+        }
+
+        public ClusterInfo(Meta Meta)
+        {
+            if (Meta != null)
+            {
+                this.Version = Meta.Version;
+                this.CreatedAt = Meta.CreatedAt;
+                this.UpdatedAt = Meta.UpdatedAt;
+            }
+        }
+
+        [DataMember(Name = "ID", EmitDefaultValue = false)]
+        public string ID { get; set; }
+
+        [DataMember(Name = "Version", EmitDefaultValue = false)]
+        public Version Version { get; set; }
+
+        [DataMember(Name = "CreatedAt", EmitDefaultValue = false)]
+        public DateTime CreatedAt { get; set; }
+
+        [DataMember(Name = "UpdatedAt", EmitDefaultValue = false)]
+        public DateTime UpdatedAt { get; set; }
+
+        [DataMember(Name = "Spec", EmitDefaultValue = false)]
+        public Spec Spec { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -19,5 +19,8 @@ namespace Docker.DotNet.Models
 
         [QueryStringParameter("detachKeys", false)]
         public string DetachKeys { get; set; }
+
+        [QueryStringParameter("logs", false)]
+        public string Logs { get; set; }
     }
 }

--- a/Docker.DotNet/Models/DispatcherConfig.Generated.cs
+++ b/Docker.DotNet/Models/DispatcherConfig.Generated.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class DispatcherConfig // (swarm.DispatcherConfig)
+    {
+        [DataMember(Name = "HeartbeatPeriod", EmitDefaultValue = false)]
+        public ulong HeartbeatPeriod { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/Driver.Generated.cs
+++ b/Docker.DotNet/Models/Driver.Generated.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Driver // (swarm.Driver)
+    {
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Options", EmitDefaultValue = false)]
+        public IDictionary<string, string> Options { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/ExternalCA.Generated.cs
+++ b/Docker.DotNet/Models/ExternalCA.Generated.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class ExternalCA // (swarm.ExternalCA)
+    {
+        [DataMember(Name = "Protocol", EmitDefaultValue = false)]
+        public string Protocol { get; set; }
+
+        [DataMember(Name = "URL", EmitDefaultValue = false)]
+        public string URL { get; set; }
+
+        [DataMember(Name = "Options", EmitDefaultValue = false)]
+        public IDictionary<string, string> Options { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/Info.Generated.cs
+++ b/Docker.DotNet/Models/Info.Generated.cs
@@ -9,6 +9,9 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "NodeID", EmitDefaultValue = false)]
         public string NodeID { get; set; }
 
+        [DataMember(Name = "NodeAddr", EmitDefaultValue = false)]
+        public string NodeAddr { get; set; }
+
         [DataMember(Name = "LocalNodeState", EmitDefaultValue = false)]
         public string LocalNodeState { get; set; }
 
@@ -27,7 +30,7 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "Managers", EmitDefaultValue = false)]
         public long Managers { get; set; }
 
-        [DataMember(Name = "CACertHash", EmitDefaultValue = false)]
-        public string CACertHash { get; set; }
+        [DataMember(Name = "Cluster", EmitDefaultValue = false)]
+        public ClusterInfo Cluster { get; set; }
     }
 }

--- a/Docker.DotNet/Models/Meta.Generated.cs
+++ b/Docker.DotNet/Models/Meta.Generated.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Meta // (swarm.Meta)
+    {
+        [DataMember(Name = "Version", EmitDefaultValue = false)]
+        public Version Version { get; set; }
+
+        [DataMember(Name = "CreatedAt", EmitDefaultValue = false)]
+        public DateTime CreatedAt { get; set; }
+
+        [DataMember(Name = "UpdatedAt", EmitDefaultValue = false)]
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/OrchestrationConfig.Generated.cs
+++ b/Docker.DotNet/Models/OrchestrationConfig.Generated.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class OrchestrationConfig // (swarm.OrchestrationConfig)
+    {
+        [DataMember(Name = "TaskHistoryRetentionLimit", EmitDefaultValue = false)]
+        public long TaskHistoryRetentionLimit { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/RaftConfig.Generated.cs
+++ b/Docker.DotNet/Models/RaftConfig.Generated.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class RaftConfig // (swarm.RaftConfig)
+    {
+        [DataMember(Name = "SnapshotInterval", EmitDefaultValue = false)]
+        public ulong SnapshotInterval { get; set; }
+
+        [DataMember(Name = "KeepOldSnapshots", EmitDefaultValue = false)]
+        public ulong KeepOldSnapshots { get; set; }
+
+        [DataMember(Name = "LogEntriesForSlowFollowers", EmitDefaultValue = false)]
+        public ulong LogEntriesForSlowFollowers { get; set; }
+
+        [DataMember(Name = "HeartbeatTick", EmitDefaultValue = false)]
+        public uint HeartbeatTick { get; set; }
+
+        [DataMember(Name = "ElectionTick", EmitDefaultValue = false)]
+        public uint ElectionTick { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/Spec.Generated.cs
+++ b/Docker.DotNet/Models/Spec.Generated.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Spec // (swarm.Spec)
+    {
+        public Spec()
+        {
+        }
+
+        public Spec(Annotations Annotations)
+        {
+            if (Annotations != null)
+            {
+                this.Name = Annotations.Name;
+                this.Labels = Annotations.Labels;
+            }
+        }
+
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Labels", EmitDefaultValue = false)]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [DataMember(Name = "Orchestration", EmitDefaultValue = false)]
+        public OrchestrationConfig Orchestration { get; set; }
+
+        [DataMember(Name = "Raft", EmitDefaultValue = false)]
+        public RaftConfig Raft { get; set; }
+
+        [DataMember(Name = "Dispatcher", EmitDefaultValue = false)]
+        public DispatcherConfig Dispatcher { get; set; }
+
+        [DataMember(Name = "CAConfig", EmitDefaultValue = false)]
+        public CAConfig CAConfig { get; set; }
+
+        [DataMember(Name = "TaskDefaults", EmitDefaultValue = false)]
+        public TaskDefaults TaskDefaults { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
+++ b/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
@@ -158,5 +158,8 @@ namespace Docker.DotNet.Models
 
         [DataMember(Name = "Swarm", EmitDefaultValue = false)]
         public Info Swarm { get; set; }
+
+        [DataMember(Name = "LiveRestoreEnabled", EmitDefaultValue = false)]
+        public bool LiveRestoreEnabled { get; set; }
     }
 }

--- a/Docker.DotNet/Models/TaskDefaults.Generated.cs
+++ b/Docker.DotNet/Models/TaskDefaults.Generated.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class TaskDefaults // (swarm.TaskDefaults)
+    {
+        [DataMember(Name = "LogDriver", EmitDefaultValue = false)]
+        public Driver LogDriver { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/Version.Generated.cs
+++ b/Docker.DotNet/Models/Version.Generated.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Version // (swarm.Version)
+    {
+        [DataMember(Name = "Index", EmitDefaultValue = false)]
+        public ulong Index { get; set; }
+    }
+}

--- a/tools/specgen/Godeps/Godeps.json
+++ b/tools/specgen/Godeps/Godeps.json
@@ -5,43 +5,43 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/docker/engine-api/types",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/blkiodev",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/container",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/filters",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/network",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/registry",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/strslice",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/versions",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
@@ -55,8 +55,8 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/swarm",
-			"Comment": "v0.3.1-232-g1d24745",
-			"Rev": "1d247454d4307fb1ddf10d09fd2996394b085904"
+			"Comment": "v0.4.0",
+			"Rev": "3d1601b9d2436a70b0dfc045a23f6503d19195df"
 		}
 	]
 }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -86,6 +86,7 @@ type ContainerAttachParameters struct {
 	Stdout     bool   `rest:"query"`
 	Stderr     bool   `rest:"query"`
 	DetachKeys string `rest:"query,detachKeys"`
+	Logs       string `rest:"query"`
 }
 
 // ContainerInspectParameters for GET /containers/(id)/json

--- a/tools/specgen/vendor/github.com/docker/engine-api/types/configs.go
+++ b/tools/specgen/vendor/github.com/docker/engine-api/types/configs.go
@@ -45,8 +45,8 @@ type ExecConfig struct {
 	Privileged   bool     // Is the container in privileged mode
 	Tty          bool     // Attach standard streams to a tty.
 	AttachStdin  bool     // Attach the standard input, makes possible user interaction
-	AttachStderr bool     // Attach the standard output
-	AttachStdout bool     // Attach the standard error
+	AttachStderr bool     // Attach the standard error
+	AttachStdout bool     // Attach the standard output
 	Detach       bool     // Execute in detach mode
 	DetachKeys   string   // Escape keys for detach
 	Cmd          []string // Execution commands and args

--- a/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/node.go
+++ b/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/node.go
@@ -15,7 +15,6 @@ type Node struct {
 type NodeSpec struct {
 	Annotations
 	Role         NodeRole         `json:",omitempty"`
-	Membership   NodeMembership   `json:",omitempty"`
 	Availability NodeAvailability `json:",omitempty"`
 }
 
@@ -27,16 +26,6 @@ const (
 	NodeRoleWorker NodeRole = "worker"
 	// NodeRoleManager MANAGER
 	NodeRoleManager NodeRole = "manager"
-)
-
-// NodeMembership represents the membership of a node.
-type NodeMembership string
-
-const (
-	// NodeMembershipPending PENDING
-	NodeMembershipPending NodeMembership = "pending"
-	// NodeMembershipAccepted ACCEPTED
-	NodeMembershipAccepted NodeMembership = "accepted"
 )
 
 // NodeAvailability represents the availability of a node.

--- a/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/service.go
+++ b/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/service.go
@@ -6,8 +6,9 @@ import "time"
 type Service struct {
 	ID string
 	Meta
-	Spec     ServiceSpec `json:",omitempty"`
-	Endpoint Endpoint    `json:",omitempty"`
+	Spec         ServiceSpec  `json:",omitempty"`
+	Endpoint     Endpoint     `json:",omitempty"`
+	UpdateStatus UpdateStatus `json:",omitempty"`
 }
 
 // ServiceSpec represents the spec of a service.
@@ -29,6 +30,26 @@ type ServiceMode struct {
 	Global     *GlobalService     `json:",omitempty"`
 }
 
+// UpdateState is the state of a service update.
+type UpdateState string
+
+const (
+	// UpdateStateUpdating is the updating state.
+	UpdateStateUpdating UpdateState = "updating"
+	// UpdateStatePaused is the paused state.
+	UpdateStatePaused UpdateState = "paused"
+	// UpdateStateCompleted is the completed state.
+	UpdateStateCompleted UpdateState = "completed"
+)
+
+// UpdateStatus reports the status of a service update.
+type UpdateStatus struct {
+	State       UpdateState `json:",omitempty"`
+	StartedAt   time.Time   `json:",omitempty"`
+	CompletedAt time.Time   `json:",omitempty"`
+	Message     string      `json:",omitempty"`
+}
+
 // ReplicatedService is a kind of ServiceMode.
 type ReplicatedService struct {
 	Replicas *uint64 `json:",omitempty"`
@@ -37,8 +58,16 @@ type ReplicatedService struct {
 // GlobalService is a kind of ServiceMode.
 type GlobalService struct{}
 
+const (
+	// UpdateFailureActionPause PAUSE
+	UpdateFailureActionPause = "pause"
+	// UpdateFailureActionContinue CONTINUE
+	UpdateFailureActionContinue = "continue"
+)
+
 // UpdateConfig represents the update configuration.
 type UpdateConfig struct {
-	Parallelism uint64        `json:",omitempty"`
-	Delay       time.Duration `json:",omitempty"`
+	Parallelism   uint64        `json:",omitempty"`
+	Delay         time.Duration `json:",omitempty"`
+	FailureAction string        `json:",omitempty"`
 }

--- a/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/tools/specgen/vendor/github.com/docker/engine-api/types/swarm/swarm.go
@@ -2,47 +2,51 @@ package swarm
 
 import "time"
 
-// Swarm represents a swarm.
-type Swarm struct {
+// ClusterInfo represents info about a the cluster for outputing in "info"
+// it contains the same information as "Swarm", but without the JoinTokens
+type ClusterInfo struct {
 	ID string
 	Meta
 	Spec Spec
+}
+
+// Swarm represents a swarm.
+type Swarm struct {
+	ClusterInfo
+	JoinTokens JoinTokens
+}
+
+// JoinTokens contains the tokens workers and managers need to join the swarm.
+type JoinTokens struct {
+	Worker  string
+	Manager string
 }
 
 // Spec represents the spec of a swarm.
 type Spec struct {
 	Annotations
 
-	AcceptancePolicy AcceptancePolicy    `json:",omitempty"`
-	Orchestration    OrchestrationConfig `json:",omitempty"`
-	Raft             RaftConfig          `json:",omitempty"`
-	Dispatcher       DispatcherConfig    `json:",omitempty"`
-	CAConfig         CAConfig            `json:",omitempty"`
-
-	// DefaultLogDriver sets the log driver to use at task creation time if
-	// unspecified by a task.
-	//
-	// Updating this value will only have an affect on new tasks. Old tasks
-	// will continue use their previously configured log driver until
-	// recreated.
-	DefaultLogDriver *Driver `json:",omitempty"`
-}
-
-// AcceptancePolicy represents the list of policies.
-type AcceptancePolicy struct {
-	Policies []Policy `json:",omitempty"`
-}
-
-// Policy represents a role, autoaccept and secret.
-type Policy struct {
-	Role       NodeRole
-	Autoaccept bool
-	Secret     *string `json:",omitempty"`
+	Orchestration OrchestrationConfig `json:",omitempty"`
+	Raft          RaftConfig          `json:",omitempty"`
+	Dispatcher    DispatcherConfig    `json:",omitempty"`
+	CAConfig      CAConfig            `json:",omitempty"`
+	TaskDefaults  TaskDefaults        `json:",omitempty"`
 }
 
 // OrchestrationConfig represents orchestration configuration.
 type OrchestrationConfig struct {
 	TaskHistoryRetentionLimit int64 `json:",omitempty"`
+}
+
+// TaskDefaults parameterizes cluster-level task creation with default values.
+type TaskDefaults struct {
+	// LogDriver selects the log driver to use for tasks created in the
+	// orchestrator if unspecified by a service.
+	//
+	// Updating this value will only have an affect on new tasks. Old tasks
+	// will continue use their previously configured log driver until
+	// recreated.
+	LogDriver *Driver `json:",omitempty"`
 }
 
 // RaftConfig represents raft configuration.
@@ -81,17 +85,17 @@ type ExternalCA struct {
 // InitRequest is the request used to init a swarm.
 type InitRequest struct {
 	ListenAddr      string
+	AdvertiseAddr   string
 	ForceNewCluster bool
 	Spec            Spec
 }
 
 // JoinRequest is the request used to join a swarm.
 type JoinRequest struct {
-	ListenAddr  string
-	RemoteAddrs []string
-	Secret      string // accept by secret
-	CACertHash  string
-	Manager     bool
+	ListenAddr    string
+	AdvertiseAddr string
+	RemoteAddrs   []string
+	JoinToken     string // accept by secret
 }
 
 // LocalNodeState represents the state of the local node.
@@ -110,7 +114,8 @@ const (
 
 // Info represents generic information about swarm.
 type Info struct {
-	NodeID string
+	NodeID   string
+	NodeAddr string
 
 	LocalNodeState   LocalNodeState
 	ControlAvailable bool
@@ -119,11 +124,18 @@ type Info struct {
 	RemoteManagers []Peer
 	Nodes          int
 	Managers       int
-	CACertHash     string
+
+	Cluster ClusterInfo
 }
 
 // Peer represents a peer.
 type Peer struct {
 	NodeID string
 	Addr   string
+}
+
+// UpdateFlags contains flags for SwarmUpdate.
+type UpdateFlags struct {
+	RotateWorkerToken  bool
+	RotateManagerToken bool
 }

--- a/tools/specgen/vendor/github.com/docker/engine-api/types/types.go
+++ b/tools/specgen/vendor/github.com/docker/engine-api/types/types.go
@@ -256,6 +256,10 @@ type Info struct {
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info
+	// LiveRestoreEnabled determines whether containers should be kept
+	// running when the daemon is shutdown or upon daemon start if
+	// running containers are detected
+	LiveRestoreEnabled bool
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -282,7 +286,7 @@ type ExecStartCheck struct {
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started
 	End      time.Time // End is the time this check ended
-	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=starting, else=error running probe
+	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=reserved (considered unhealthy), else=error running probe
 	Output   string    // Output from last check
 }
 


### PR DESCRIPTION
Resolves: #128 - Adds the 'Logs' parameter to ContainerAttachParameters as
the docker cli didnt use this property even though the daemon supported
it.

Partially implements: #119 - Adds the swarm/services and node models but
doesnt add any endpoint behavior.