### PR TITLE
Updated Docker documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ limitations under the License.
 * [Justin Terry](https://github.com/jterry75)
 * [Stefan J. Wernli](https://github.com/swernli)
 
-[docker-remote-api]: https://docs.docker.com/reference/api/docker_remote_api/
-[v1.14]: https://docs.docker.com/reference/api/docker_remote_api_v1.14/
+[docker-remote-api]: https://docs.docker.com/engine/reference/api/docker_remote_api/
 [docker-tls]: https://docs.docker.com/articles/https/
 [nuget]: http://www.nuget.org
 [nuget-gallery]: https://www.nuget.org/packages/Docker.DotNet/


### PR DESCRIPTION
Looks like Docker changed their url for their api documentation, so I updated the link. The `v1.14` link also wasn't in use, so I dropped it as well.