### PR TITLE
Fixes an issue with nullable primitive types.

### DIFF
--- a/Docker.DotNet/Models/Config.Generated.cs
+++ b/Docker.DotNet/Models/Config.Generated.cs
@@ -76,7 +76,7 @@ namespace Docker.DotNet.Models
         public string StopSignal { get; set; }
 
         [DataMember(Name = "StopTimeout", EmitDefaultValue = false)]
-        public long StopTimeout { get; set; }
+        public long? StopTimeout { get; set; }
 
         [DataMember(Name = "Shell", EmitDefaultValue = false)]
         public IList<string> Shell { get; set; }

--- a/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
+++ b/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
@@ -101,10 +101,10 @@ namespace Docker.DotNet.Models
         public GraphDriverData GraphDriver { get; set; }
 
         [DataMember(Name = "SizeRw", EmitDefaultValue = false)]
-        public long SizeRw { get; set; }
+        public long? SizeRw { get; set; }
 
         [DataMember(Name = "SizeRootFs", EmitDefaultValue = false)]
-        public long SizeRootFs { get; set; }
+        public long? SizeRootFs { get; set; }
 
         [DataMember(Name = "Mounts", EmitDefaultValue = false)]
         public IList<MountPoint> Mounts { get; set; }

--- a/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
+++ b/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
@@ -68,9 +68,9 @@ namespace Docker.DotNet.Models
         public GraphDriverData GraphDriver { get; set; }
 
         [DataMember(Name = "SizeRw", EmitDefaultValue = false)]
-        public long SizeRw { get; set; }
+        public long? SizeRw { get; set; }
 
         [DataMember(Name = "SizeRootFs", EmitDefaultValue = false)]
-        public long SizeRootFs { get; set; }
+        public long? SizeRootFs { get; set; }
     }
 }

--- a/Docker.DotNet/Models/ContainerUpdateParameters.Generated.cs
+++ b/Docker.DotNet/Models/ContainerUpdateParameters.Generated.cs
@@ -99,10 +99,10 @@ namespace Docker.DotNet.Models
         public long MemorySwap { get; set; }
 
         [DataMember(Name = "MemorySwappiness", EmitDefaultValue = false)]
-        public long MemorySwappiness { get; set; }
+        public long? MemorySwappiness { get; set; }
 
         [DataMember(Name = "OomKillDisable", EmitDefaultValue = false)]
-        public bool OomKillDisable { get; set; }
+        public bool? OomKillDisable { get; set; }
 
         [DataMember(Name = "PidsLimit", EmitDefaultValue = false)]
         public long PidsLimit { get; set; }

--- a/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -115,7 +115,7 @@ namespace Docker.DotNet.Models
         public string StopSignal { get; set; }
 
         [DataMember(Name = "StopTimeout", EmitDefaultValue = false)]
-        public long StopTimeout { get; set; }
+        public long? StopTimeout { get; set; }
 
         [DataMember(Name = "Shell", EmitDefaultValue = false)]
         public IList<string> Shell { get; set; }

--- a/Docker.DotNet/Models/HostConfig.Generated.cs
+++ b/Docker.DotNet/Models/HostConfig.Generated.cs
@@ -200,10 +200,10 @@ namespace Docker.DotNet.Models
         public long MemorySwap { get; set; }
 
         [DataMember(Name = "MemorySwappiness", EmitDefaultValue = false)]
-        public long MemorySwappiness { get; set; }
+        public long? MemorySwappiness { get; set; }
 
         [DataMember(Name = "OomKillDisable", EmitDefaultValue = false)]
-        public bool OomKillDisable { get; set; }
+        public bool? OomKillDisable { get; set; }
 
         [DataMember(Name = "PidsLimit", EmitDefaultValue = false)]
         public long PidsLimit { get; set; }

--- a/Docker.DotNet/Models/Resources.Generated.cs
+++ b/Docker.DotNet/Models/Resources.Generated.cs
@@ -61,10 +61,10 @@ namespace Docker.DotNet.Models
         public long MemorySwap { get; set; }
 
         [DataMember(Name = "MemorySwappiness", EmitDefaultValue = false)]
-        public long MemorySwappiness { get; set; }
+        public long? MemorySwappiness { get; set; }
 
         [DataMember(Name = "OomKillDisable", EmitDefaultValue = false)]
-        public bool OomKillDisable { get; set; }
+        public bool? OomKillDisable { get; set; }
 
         [DataMember(Name = "PidsLimit", EmitDefaultValue = false)]
         public long PidsLimit { get; set; }

--- a/Docker.DotNet/Models/UpdateConfig.Generated.cs
+++ b/Docker.DotNet/Models/UpdateConfig.Generated.cs
@@ -98,10 +98,10 @@ namespace Docker.DotNet.Models
         public long MemorySwap { get; set; }
 
         [DataMember(Name = "MemorySwappiness", EmitDefaultValue = false)]
-        public long MemorySwappiness { get; set; }
+        public long? MemorySwappiness { get; set; }
 
         [DataMember(Name = "OomKillDisable", EmitDefaultValue = false)]
-        public bool OomKillDisable { get; set; }
+        public bool? OomKillDisable { get; set; }
 
         [DataMember(Name = "PidsLimit", EmitDefaultValue = false)]
         public long PidsLimit { get; set; }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -342,6 +342,7 @@ func reflectTypeMembers(t reflect.Type, m *CSModelType, reflectedTypes map[strin
 				a := CSAttribute{Type: CSType{"", "DataMember", false}}
 				a.NamedArguments = append(a.NamedArguments, CSNamedArgument{"Name", CSArgument{jsonName, CSInboxTypesMap[reflect.String]}})
 				a.NamedArguments = append(a.NamedArguments, CSNamedArgument{"EmitDefaultValue", CSArgument{strconv.FormatBool(false), CSInboxTypesMap[reflect.Bool]}})
+				csProp.IsOpt = f.Type.Kind() == reflect.Ptr
 				csProp.Attributes = append(csProp.Attributes, a)
 			}
 


### PR DESCRIPTION
Resolves: #140. When a `*primitive` in Go converts to C# the only possible
conversion is to call this a `primitive?` to maintain the nullablility.