### PR TITLE
Fixes map[string]struct{} as dictionary

### DIFF
--- a/Docker.DotNet/Models/Config.Generated.cs
+++ b/Docker.DotNet/Models/Config.Generated.cs
@@ -52,7 +52,7 @@ namespace Docker.DotNet.Models
         public string Image { get; set; }
 
         [DataMember(Name = "Volumes", EmitDefaultValue = false)]
-        public IDictionary<string, object> Volumes { get; set; }
+        public IList<string> Volumes { get; set; }
 
         [DataMember(Name = "WorkingDir", EmitDefaultValue = false)]
         public string WorkingDir { get; set; }

--- a/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -91,7 +91,7 @@ namespace Docker.DotNet.Models
         public string Image { get; set; }
 
         [DataMember(Name = "Volumes", EmitDefaultValue = false)]
-        public IDictionary<string, object> Volumes { get; set; }
+        public IList<string> Volumes { get; set; }
 
         [DataMember(Name = "WorkingDir", EmitDefaultValue = false)]
         public string WorkingDir { get; set; }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -16,6 +16,7 @@ import (
 )
 
 var typeCustomizations = map[typeCustomizationKey]CSType{
+	{reflect.TypeOf(container.Config{}), "Volumes"}:        {"System.Collections.Generic", "IList<string>", false},
 	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:    {"", "RestartPolicyKind", false},
 	{reflect.TypeOf(types.Container{}), "Created"}:         {"System", "DateTime", false},
 	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:      {"", "FileSystemChangeKind", false},


### PR DESCRIPTION
Resolves: #139 in that docker handles Config.Volumes very specifically.
Rather than being a map of string struct it actually only uses the keys
which serializes as a flat list of string.