### PR TITLE
Implement /events return type.

### DIFF
--- a/src/Docker.DotNet/Models/Actor.Generated.cs
+++ b/src/Docker.DotNet/Models/Actor.Generated.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Actor // (events.Actor)
+    {
+        [DataMember(Name = "ID", EmitDefaultValue = false)]
+        public string ID { get; set; }
+
+        [DataMember(Name = "Attributes", EmitDefaultValue = false)]
+        public IDictionary<string, string> Attributes { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/EventsMessage.Generated.cs
+++ b/src/Docker.DotNet/Models/EventsMessage.Generated.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class EventsMessage // (events.Message)
+    {
+        [DataMember(Name = "status", EmitDefaultValue = false)]
+        public string Status { get; set; }
+
+        [DataMember(Name = "id", EmitDefaultValue = false)]
+        public string ID { get; set; }
+
+        [DataMember(Name = "from", EmitDefaultValue = false)]
+        public string From { get; set; }
+
+        [DataMember(Name = "Type", EmitDefaultValue = false)]
+        public string Type { get; set; }
+
+        [DataMember(Name = "Action", EmitDefaultValue = false)]
+        public string Action { get; set; }
+
+        [DataMember(Name = "Actor", EmitDefaultValue = false)]
+        public Actor Actor { get; set; }
+
+        [DataMember(Name = "time", EmitDefaultValue = false)]
+        public DateTime Time { get; set; }
+
+        [DataMember(Name = "timeNano", EmitDefaultValue = false)]
+        public long TimeNano { get; set; }
+    }
+}

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/events"
 	"github.com/docker/engine-api/types/registry"
 )
 
 var typeCustomizations = map[typeCustomizationKey]CSType{
 	{reflect.TypeOf(container.Config{}), "Volumes"}:        {"System.Collections.Generic", "IList<string>", false},
 	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:    {"", "RestartPolicyKind", false},
+	{reflect.TypeOf(events.Message{}), "Time"}:             {"System", "DateTime", false},
 	{reflect.TypeOf(types.Container{}), "Created"}:         {"System", "DateTime", false},
 	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:      {"", "FileSystemChangeKind", false},
 	{reflect.TypeOf(types.ContainerJSONBase{}), "Created"}: {"System", "DateTime", false},
@@ -135,6 +137,7 @@ var dockerTypesToReflect = []typeDef{
 
 	// GET /events
 	{reflect.TypeOf(ContainerEventsParameters{}), "ContainerEventsParameters"},
+	{reflect.TypeOf(events.Message{}), "EventsMessage"},
 
 	// POST /images/create
 	{reflect.TypeOf(ImageCreateParameters{}), "ImagesCreateParameters"},

--- a/tools/specgen/update-generated-code.cmd
+++ b/tools/specgen/update-generated-code.cmd
@@ -1,3 +1,3 @@
 go build
-specgen.exe ..\..\Docker.DotNet\Models
+specgen.exe ..\..\src\Docker.DotNet\Models
 del specgen.exe


### PR DESCRIPTION
For the v1.12.0 release the return type of /events was the
events.Message type in go. This adds that type to the reflection api's
to generate it for the return streams.