### PR TITLE
Fix HttpMethod bug in Connect/DisconnectNetworkAsync

### DIFF
--- a/src/Docker.DotNet/Endpoints/NetworkOperations.cs
+++ b/src/Docker.DotNet/Endpoints/NetworkOperations.cs
@@ -38,7 +38,7 @@ namespace Docker.DotNet
             }
 
             var data = new JsonRequestContent<NetworkConnectParameters>(parameters, this._client.JsonSerializer);
-            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, $"networks/{id}/connect", null, data);
+            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Post, $"networks/{id}/connect", null, data);
         }
 
         public async Task<NetworksCreateResponse> CreateNetworkAsync(NetworksCreateParameters parameters)
@@ -76,7 +76,7 @@ namespace Docker.DotNet
             }
 
             var data = new JsonRequestContent<NetworkDisconnectParameters>(parameters, this._client.JsonSerializer);
-            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Get, $"networks/{id}/disconnect", null, data);
+            return this._client.MakeRequestAsync(new[] { NoSuchNetworkHandler }, HttpMethod.Post, $"networks/{id}/disconnect", null, data);
         }
 
         public async Task<NetworkResponse> InspectNetworkAsync(string id)


### PR DESCRIPTION
ConnectNetworkAsync and DisconnectNetworkAsync were making GET request (+ body) when POST is expected. This resulted in 404 response with the error 

> network {network-id}/connect not found

Code has been updated to use POST