### PR TITLE
TimeSpan Feature

### DIFF
--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -14,7 +14,8 @@ namespace Docker.DotNet
         {
             JsonConvert.DefaultSettings = () => new JsonSerializerSettings
             {
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new TimeSpanContractResolver()
             };
         }
 

--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -25,7 +25,9 @@ namespace Docker.DotNet
             {
                 new JsonIso8601AndUnixEpochDateConverter(),
                 new JsonVersionConverter(),
-                new StringEnumConverter()
+                new StringEnumConverter(),
+                new TimeSpanSecondsConverter(),
+                new TimeSpanNanosecondsConverter()
             };
         }
 

--- a/src/Docker.DotNet/Models/Config.Generated.cs
+++ b/src/Docker.DotNet/Models/Config.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -76,7 +77,8 @@ namespace Docker.DotNet.Models
         public string StopSignal { get; set; }
 
         [DataMember(Name = "StopTimeout", EmitDefaultValue = false)]
-        public long? StopTimeout { get; set; }
+        [TimeSpanSerialization(SerializationTarget.Seconds)]
+        public TimeSpan? StopTimeout { get; set; }
 
         [DataMember(Name = "Shell", EmitDefaultValue = false)]
         public IList<string> Shell { get; set; }

--- a/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -115,7 +116,8 @@ namespace Docker.DotNet.Models
         public string StopSignal { get; set; }
 
         [DataMember(Name = "StopTimeout", EmitDefaultValue = false)]
-        public long? StopTimeout { get; set; }
+        [TimeSpanSerialization(SerializationTarget.Seconds)]
+        public TimeSpan? StopTimeout { get; set; }
 
         [DataMember(Name = "Shell", EmitDefaultValue = false)]
         public IList<string> Shell { get; set; }

--- a/src/Docker.DotNet/Models/HealthConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/HealthConfig.Generated.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -10,10 +11,12 @@ namespace Docker.DotNet.Models
         public IList<string> Test { get; set; }
 
         [DataMember(Name = "Interval", EmitDefaultValue = false)]
-        public long Interval { get; set; }
+        [TimeSpanSerialization(SerializationTarget.Nanoseconds)]
+        public TimeSpan Interval { get; set; }
 
         [DataMember(Name = "Timeout", EmitDefaultValue = false)]
-        public long Timeout { get; set; }
+        [TimeSpanSerialization(SerializationTarget.Nanoseconds)]
+        public TimeSpan Timeout { get; set; }
 
         [DataMember(Name = "Retries", EmitDefaultValue = false)]
         public long Retries { get; set; }

--- a/src/Docker.DotNet/TimeSpanContractResolver.cs
+++ b/src/Docker.DotNet/TimeSpanContractResolver.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Docker.DotNet
+{
+    internal class TimeSpanContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var jsonProperty = base.CreateProperty(member, memberSerialization);
+
+            var timeSpanAttribute = member.GetCustomAttribute<TimeSpanSerializationAttribute>(false);
+            if (timeSpanAttribute != null)
+            {
+                if (timeSpanAttribute.TargetSerialization == SerializationTarget.Seconds)
+                {
+                    jsonProperty.Converter = new TimeSpanSecondsConverter();
+                }
+                else if (timeSpanAttribute.TargetSerialization == SerializationTarget.Nanoseconds)
+                {
+                    jsonProperty.Converter = new TimeSpanNanosecondsConverter();
+                }
+            }
+            return jsonProperty;
+        }
+    }
+}

--- a/src/Docker.DotNet/TimeSpanNanoSecondsConverter.cs
+++ b/src/Docker.DotNet/TimeSpanNanoSecondsConverter.cs
@@ -14,24 +14,25 @@ namespace Docker.DotNet
                 return;
             }
 
-            writer.WriteValue(timeSpan.Value.TotalMilliseconds * MiliSecondToNanoSecond);
+            writer.WriteValue((long)(timeSpan.Value.TotalMilliseconds * MiliSecondToNanoSecond));
         }
 
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(TimeSpan);
+            return objectType == typeof(TimeSpan) || objectType == typeof(TimeSpan?);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            var valueInNanoSeconds = reader.ReadAsDouble();
+            var valueInNanoSeconds = (long?)reader.Value;
+
             if (!valueInNanoSeconds.HasValue)
             {
                 return null;
             }
             var miliSecondValue = valueInNanoSeconds.Value / MiliSecondToNanoSecond;
 
-            return TimeSpan.FromMilliseconds(miliSecondValue);
+            return TimeSpan.FromMilliseconds((long)miliSecondValue);
         }
     }
 }

--- a/src/Docker.DotNet/TimeSpanNanoSecondsConverter.cs
+++ b/src/Docker.DotNet/TimeSpanNanoSecondsConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Docker.DotNet
+{
+    internal class TimeSpanNanosecondsConverter : JsonConverter
+    {
+        const int MiliSecondToNanoSecond = 1000000;
+        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var timeSpan = value as TimeSpan?;
+            if (timeSpan == null)
+            {
+                return;
+            }
+
+            writer.WriteValue(timeSpan.Value.TotalMilliseconds * MiliSecondToNanoSecond);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(TimeSpan);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var valueInNanoSeconds = reader.ReadAsDouble();
+            if (!valueInNanoSeconds.HasValue)
+            {
+                return null;
+            }
+            var miliSecondValue = valueInNanoSeconds.Value / MiliSecondToNanoSecond;
+
+            return TimeSpan.FromMilliseconds(miliSecondValue);
+        }
+    }
+}

--- a/src/Docker.DotNet/TimeSpanSecondsConverter.cs
+++ b/src/Docker.DotNet/TimeSpanSecondsConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Docker.DotNet
 {
@@ -13,19 +14,18 @@ namespace Docker.DotNet
                 return;
             }
 
-            writer.WriteValue(timeSpan.Value.TotalSeconds);
+            writer.WriteValue((long)timeSpan.Value.TotalSeconds);
         }
 
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(TimeSpan);
+            return objectType == typeof(TimeSpan) || objectType == typeof(TimeSpan?);
         }
-
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            var valueInSeconds = reader.ReadAsInt32();
-            if (!valueInSeconds.HasValue)
+            var valueInSeconds = (long?)reader.Value;
+            if(!valueInSeconds.HasValue)
             {
                 return null;
             }

--- a/src/Docker.DotNet/TimeSpanSecondsConverter.cs
+++ b/src/Docker.DotNet/TimeSpanSecondsConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Docker.DotNet
+{
+    internal class TimeSpanSecondsConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var timeSpan = value as TimeSpan?;
+            if (timeSpan == null)
+            {
+                return;
+            }
+
+            writer.WriteValue(timeSpan.Value.TotalSeconds);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(TimeSpan);
+        }
+
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var valueInSeconds = reader.ReadAsInt32();
+            if (!valueInSeconds.HasValue)
+            {
+                return null;
+            }
+
+            return TimeSpan.FromSeconds(valueInSeconds.Value);
+        }
+    }
+}

--- a/src/Docker.DotNet/TimeSpanSerializationAttribute.cs
+++ b/src/Docker.DotNet/TimeSpanSerializationAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Docker.DotNet
+{    
+    internal enum SerializationTarget
+    {
+        Seconds,
+        Nanoseconds
+    }
+
+    [AttributeUsage(validOn: AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    internal class TimeSpanSerializationAttribute : Attribute
+    {
+        public SerializationTarget TargetSerialization { get; private set; }
+
+        public TimeSpanSerializationAttribute(SerializationTarget target)
+        {
+            TargetSerialization = target;
+        }
+    }
+}

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -18,14 +18,25 @@ import (
 )
 
 var typeCustomizations = map[typeCustomizationKey]CSType{
-	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:    {"", "RestartPolicyKind", false},
-	{reflect.TypeOf(jsonmessage.JSONMessage{}), "Time"}:    {"System", "DateTime", false},
-	{reflect.TypeOf(types.Container{}), "Created"}:         {"System", "DateTime", false},
-	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:      {"", "FileSystemChangeKind", false},
-	{reflect.TypeOf(types.ContainerJSONBase{}), "Created"}: {"System", "DateTime", false},
-	{reflect.TypeOf(types.ImageSummary{}), "Created"}:      {"System", "DateTime", false},
-	{reflect.TypeOf(types.ImageHistory{}), "Created"}:      {"System", "DateTime", false},
-	{reflect.TypeOf(types.ImageInspect{}), "Created"}:      {"System", "DateTime", false},
+	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:          {"", "RestartPolicyKind", false},
+	{reflect.TypeOf(jsonmessage.JSONMessage{}), "Time"}:          {"System", "DateTime", false},
+	{reflect.TypeOf(types.Container{}), "Created"}:               {"System", "DateTime", false},
+	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:            {"", "FileSystemChangeKind", false},
+	{reflect.TypeOf(types.ContainerJSONBase{}), "Created"}:       {"System", "DateTime", false},
+	{reflect.TypeOf(types.ImageSummary{}), "Created"}:            {"System", "DateTime", false},
+	{reflect.TypeOf(types.ImageHistory{}), "Created"}:            {"System", "DateTime", false},
+	{reflect.TypeOf(types.ImageInspect{}), "Created"}:            {"System", "DateTime", false},
+	{reflect.TypeOf(container.Config{}), "StopTimeout"}:          {"System", "TimeSpan", true},
+	{reflect.TypeOf(container.HealthConfig{}), "Interval"}:       {"System", "TimeSpan", true},
+	{reflect.TypeOf(container.HealthConfig{}), "Timeout"}:        {"System", "TimeSpan", true},
+	{reflect.TypeOf(ContainerCreateParameters{}), "StopTimeout"}: {"System", "TimeSpan", true},
+}
+
+var customTypeAttribtues = map[typeCustomizationKey]CSAttribute{
+	{reflect.TypeOf(container.Config{}), "StopTimeout"}:          {Type: CSType{"Docker.DotNet", "TimeSpanSerialization", false}, Arguments: []CSArgument{{Value: "SerializationTarget.Seconds"}}},
+	{reflect.TypeOf(container.HealthConfig{}), "Interval"}:       {Type: CSType{"Docker.DotNet", "TimeSpanSerialization", false}, Arguments: []CSArgument{{Value: "SerializationTarget.Nanoseconds"}}},
+	{reflect.TypeOf(container.HealthConfig{}), "Timeout"}:        {Type: CSType{"Docker.DotNet", "TimeSpanSerialization", false}, Arguments: []CSArgument{{Value: "SerializationTarget.Nanoseconds"}}},
+	{reflect.TypeOf(ContainerCreateParameters{}), "StopTimeout"}: {Type: CSType{"Docker.DotNet", "TimeSpanSerialization", false}, Arguments: []CSArgument{{Value: "SerializationTarget.Seconds"}}},
 }
 
 type typeCustomizationKey struct {
@@ -391,6 +402,11 @@ func reflectTypeMembers(t reflect.Type, m *CSModelType, reflectedTypes map[strin
 				a.NamedArguments = append(a.NamedArguments, CSNamedArgument{"EmitDefaultValue", CSArgument{strconv.FormatBool(false), CSInboxTypesMap[reflect.Bool]}})
 				csProp.IsOpt = f.Type.Kind() == reflect.Ptr
 				csProp.Attributes = append(csProp.Attributes, a)
+			}
+
+			if ca, ok := customTypeAttribtues[typeCustomizationKey{t, f.Name}]; ok {
+				// We have a custom modification. Change the type.
+				csProp.Attributes = append(csProp.Attributes, ca)
 			}
 
 			// Lastly assign the property to our type.


### PR DESCRIPTION
For Issue #98 Added support for ```TimeSpan```
This required a change both in specgen as well as the JsonConvert

specgen now has a second map[] that will map a CSType to CSAttribute, which are applied in ```reflectTypeMembers```

Added an attribute ```TimeSpanSerializationAttribute``` to decorate Properties to denote if they should be serialized in Seconds or Nanoseconds

Here is a sample of the  generated code
```csharp
    [DataContract]
    public class HealthConfig // (container.HealthConfig)
    {
        [DataMember(Name = "Test", EmitDefaultValue = false)]
        public IList<string> Test { get; set; }

        [DataMember(Name = "Interval", EmitDefaultValue = false)]
        [TimeSpanSerialization(SerializationTarget.Nanoseconds)]
        public TimeSpan Interval { get; set; }

        [DataMember(Name = "Timeout", EmitDefaultValue = false)]
        [TimeSpanSerialization(SerializationTarget.Nanoseconds)]
        public TimeSpan Timeout { get; set; }

        [DataMember(Name = "Retries", EmitDefaultValue = false)]
        public long Retries { get; set; }
    }
```

Wrote a very simple test program and got passing results.