### PR TITLE
Added example of named pipes URI to connect to local Docker for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ using Docker.DotNet;
 DockerClient client = new DockerClientConfiguration(new Uri("http://ubuntu-docker.cloudapp.net:4243"))
      .CreateClient();
 ```
+or to connect to your local [Docker for Windows](https://docs.docker.com/docker-for-windows/) deamon using named pipes:
+
+```csharp
+using Docker.DotNet;
+DockerClient client = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"))
+     .CreateClient();
+```
 
 #### Example: List containers
 


### PR DESCRIPTION
Took me a long time to figure out how to connect to the local daemon without exposing it on port 2375 (should have started with the code).
This should really be documented as it is a common use case.
