### PR TITLE
Fixing swarm inspect type and adding Nodes types

### DIFF
--- a/src/Docker.DotNet/Endpoints/ISwarmOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ISwarmOperations.cs
@@ -41,7 +41,7 @@ namespace Docker.DotNet
         /// 500 - Server Error.
         /// 503 - Node is not part of a swarm.
         /// </remarks>
-        Task<ClusterInfo> InspectSwarmAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<SwarmInspectResponse> InspectSwarmAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Join an existing swarm.

--- a/src/Docker.DotNet/Endpoints/SwarmOperations.cs
+++ b/src/Docker.DotNet/Endpoints/SwarmOperations.cs
@@ -58,10 +58,10 @@ namespace Docker.DotNet
             return this._client.JsonSerializer.DeserializeObject<SwarmService>(response.Body);
         }
 
-        async Task<ClusterInfo> ISwarmOperations.InspectSwarmAsync(CancellationToken cancellationToken)
+        async Task<SwarmInspectResponse> ISwarmOperations.InspectSwarmAsync(CancellationToken cancellationToken)
         {
             var response = await this._client.MakeRequestAsync(new []{ SwarmResponseHandler }, HttpMethod.Get, "swarm", cancellationToken).ConfigureAwait(false);
-            return this._client.JsonSerializer.DeserializeObject<ClusterInfo>(response.Body);
+            return this._client.JsonSerializer.DeserializeObject<SwarmInspectResponse>(response.Body);
         }
 
         async Task ISwarmOperations.JoinSwarmAsync(SwarmJoinParameters parameters, CancellationToken cancellationToken)

--- a/src/Docker.DotNet/Models/EngineDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/EngineDescription.Generated.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class EngineDescription // (swarm.EngineDescription)
+    {
+        [DataMember(Name = "EngineVersion", EmitDefaultValue = false)]
+        public string EngineVersion { get; set; }
+
+        [DataMember(Name = "Labels", EmitDefaultValue = false)]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [DataMember(Name = "Plugins", EmitDefaultValue = false)]
+        public IList<PluginDescription> Plugins { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/JoinTokens.Generated.cs
+++ b/src/Docker.DotNet/Models/JoinTokens.Generated.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class JoinTokens // (swarm.JoinTokens)
+    {
+        [DataMember(Name = "Worker", EmitDefaultValue = false)]
+        public string Worker { get; set; }
+
+        [DataMember(Name = "Manager", EmitDefaultValue = false)]
+        public string Manager { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/ManagerStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/ManagerStatus.Generated.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class ManagerStatus // (swarm.ManagerStatus)
+    {
+        [DataMember(Name = "Leader", EmitDefaultValue = false)]
+        public bool Leader { get; set; }
+
+        [DataMember(Name = "Reachability", EmitDefaultValue = false)]
+        public string Reachability { get; set; }
+
+        [DataMember(Name = "Addr", EmitDefaultValue = false)]
+        public string Addr { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/NodeDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeDescription.Generated.cs
@@ -1,0 +1,20 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class NodeDescription // (swarm.NodeDescription)
+    {
+        [DataMember(Name = "Hostname", EmitDefaultValue = false)]
+        public string Hostname { get; set; }
+
+        [DataMember(Name = "Platform", EmitDefaultValue = false)]
+        public Platform Platform { get; set; }
+
+        [DataMember(Name = "Resources", EmitDefaultValue = false)]
+        public Resources Resources { get; set; }
+
+        [DataMember(Name = "Engine", EmitDefaultValue = false)]
+        public EngineDescription Engine { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/NodeListResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeListResponse.Generated.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class NodeListResponse // (swarm.Node)
+    {
+        public NodeListResponse()
+        {
+        }
+
+        public NodeListResponse(Meta Meta)
+        {
+            if (Meta != null)
+            {
+                this.Version = Meta.Version;
+                this.CreatedAt = Meta.CreatedAt;
+                this.UpdatedAt = Meta.UpdatedAt;
+            }
+        }
+
+        [DataMember(Name = "ID", EmitDefaultValue = false)]
+        public string ID { get; set; }
+
+        [DataMember(Name = "Version", EmitDefaultValue = false)]
+        public Version Version { get; set; }
+
+        [DataMember(Name = "CreatedAt", EmitDefaultValue = false)]
+        public DateTime CreatedAt { get; set; }
+
+        [DataMember(Name = "UpdatedAt", EmitDefaultValue = false)]
+        public DateTime UpdatedAt { get; set; }
+
+        [DataMember(Name = "Spec", EmitDefaultValue = false)]
+        public NodeSpec Spec { get; set; }
+
+        [DataMember(Name = "Description", EmitDefaultValue = false)]
+        public NodeDescription Description { get; set; }
+
+        [DataMember(Name = "Status", EmitDefaultValue = false)]
+        public NodeStatus Status { get; set; }
+
+        [DataMember(Name = "ManagerStatus", EmitDefaultValue = false)]
+        public ManagerStatus ManagerStatus { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/NodeSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeSpec.Generated.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class NodeSpec // (swarm.NodeSpec)
+    {
+        public NodeSpec()
+        {
+        }
+
+        public NodeSpec(Annotations Annotations)
+        {
+            if (Annotations != null)
+            {
+                this.Name = Annotations.Name;
+                this.Labels = Annotations.Labels;
+            }
+        }
+
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Labels", EmitDefaultValue = false)]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [DataMember(Name = "Role", EmitDefaultValue = false)]
+        public string Role { get; set; }
+
+        [DataMember(Name = "Availability", EmitDefaultValue = false)]
+        public string Availability { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/NodeStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeStatus.Generated.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class NodeStatus // (swarm.NodeStatus)
+    {
+        [DataMember(Name = "State", EmitDefaultValue = false)]
+        public string State { get; set; }
+
+        [DataMember(Name = "Message", EmitDefaultValue = false)]
+        public string Message { get; set; }
+
+        [DataMember(Name = "Addr", EmitDefaultValue = false)]
+        public string Addr { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/NodeUpdateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeUpdateParameters.Generated.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class NodeUpdateParameters // (swarm.NodeSpec)
+    {
+        public NodeUpdateParameters()
+        {
+        }
+
+        public NodeUpdateParameters(Annotations Annotations)
+        {
+            if (Annotations != null)
+            {
+                this.Name = Annotations.Name;
+                this.Labels = Annotations.Labels;
+            }
+        }
+
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Labels", EmitDefaultValue = false)]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [DataMember(Name = "Role", EmitDefaultValue = false)]
+        public string Role { get; set; }
+
+        [DataMember(Name = "Availability", EmitDefaultValue = false)]
+        public string Availability { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/Platform.Generated.cs
+++ b/src/Docker.DotNet/Models/Platform.Generated.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class Platform // (swarm.Platform)
+    {
+        [DataMember(Name = "Architecture", EmitDefaultValue = false)]
+        public string Architecture { get; set; }
+
+        [DataMember(Name = "OS", EmitDefaultValue = false)]
+        public string OS { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/PluginDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginDescription.Generated.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class PluginDescription // (swarm.PluginDescription)
+    {
+        [DataMember(Name = "Type", EmitDefaultValue = false)]
+        public string Type { get; set; }
+
+        [DataMember(Name = "Name", EmitDefaultValue = false)]
+        public string Name { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/SwarmInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmInspectResponse.Generated.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class SwarmInspectResponse // (swarm.Swarm)
+    {
+        public SwarmInspectResponse()
+        {
+        }
+
+        public SwarmInspectResponse(ClusterInfo ClusterInfo)
+        {
+            if (ClusterInfo != null)
+            {
+                this.ID = ClusterInfo.ID;
+                this.Version = ClusterInfo.Version;
+                this.CreatedAt = ClusterInfo.CreatedAt;
+                this.UpdatedAt = ClusterInfo.UpdatedAt;
+                this.Spec = ClusterInfo.Spec;
+            }
+        }
+
+        [DataMember(Name = "ID", EmitDefaultValue = false)]
+        public string ID { get; set; }
+
+        [DataMember(Name = "Version", EmitDefaultValue = false)]
+        public Version Version { get; set; }
+
+        [DataMember(Name = "CreatedAt", EmitDefaultValue = false)]
+        public DateTime CreatedAt { get; set; }
+
+        [DataMember(Name = "UpdatedAt", EmitDefaultValue = false)]
+        public DateTime UpdatedAt { get; set; }
+
+        [DataMember(Name = "Spec", EmitDefaultValue = false)]
+        public Spec Spec { get; set; }
+
+        [DataMember(Name = "JoinTokens", EmitDefaultValue = false)]
+        public JoinTokens JoinTokens { get; set; }
+    }
+}

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -236,7 +236,7 @@ type NetworkListParameters struct {
 	Filters Args `rest:"query"`
 }
 
-// NetworkDeleteUnusedParameters for POST /networks/prune
+// NetworksDeleteUnusedParameters for POST /networks/prune
 type NetworksDeleteUnusedParameters struct {
 	Filters Args `rest:"query"`
 }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -229,6 +229,7 @@ var dockerTypesToReflect = []typeDef{
 	{reflect.TypeOf(SwarmLeaveParameters{}), "SwarmLeaveParameters"},
 
 	// GET /swarm
+	{reflect.TypeOf(swarm.Swarm{}), "SwarmInspectResponse"},
 
 	// GET /swarm/unlockkey
 	{reflect.TypeOf(swarm.UnlockRequest{}), "SwarmUnlockResponse"},
@@ -254,6 +255,15 @@ var dockerTypesToReflect = []typeDef{
 	{reflect.TypeOf(types.ServiceUpdateResponse{}), "ServiceUpdateResponse"},
 
 	// DELETE /services/(id)
+
+	// GET /nodes
+	// GET /nodes/(id)
+	{reflect.TypeOf(swarm.Node{}), "NodeListResponse"},
+
+	// DELETE /nodes/(id)
+
+	// POST /nodes/(id)/update
+	{reflect.TypeOf(swarm.NodeSpec{}), "NodeUpdateParameters"},
 }
 
 func csType(t reflect.Type, opt bool) CSType {


### PR DESCRIPTION
This change updates the swarm inspect type to match the type returned by docker (swarm.Swarm) and
adds the types for /nodes/ endpoint operations.