### PR TITLE
fix image operations create http method

### DIFF
--- a/src/Docker.DotNet/Endpoints/ImageOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ImageOperations.cs
@@ -122,19 +122,17 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            HttpMethod httpMethod = HttpMethod.Get;
             BinaryRequestContent content = null;
             if (imageStream != null)
             {
                 content = new BinaryRequestContent(imageStream, TarContentType);
-                httpMethod = HttpMethod.Post;
                 parameters.FromSrc = ImportFromBodySource;
             }
 
             IQueryString queryParameters = new QueryString<ImagesCreateParameters>(parameters);
 
             return StreamUtil.MonitorStreamForMessagesAsync(
-                this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, httpMethod, "images/create", queryParameters, content, RegistryAuthHeaders(authConfig), cancellationToken),
+                this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Post, "images/create", queryParameters, content, RegistryAuthHeaders(authConfig), cancellationToken),
                 this._client,
                 cancellationToken,
                 progress);


### PR DESCRIPTION
The call to "images/create" was set as an http get unless you passed a stream source. This results in a 404 when trying to pull an image from a registry.

repro snippet:

```c#
using System;
using Docker.DotNet;
using Docker.DotNet.Models;

namespace Docker_API_Testing
{
  class Program
  {
    static void Main(string[] args)
    {
      var client = new DockerClientConfiguration(new Uri("tcp://127.0.0.1:2375")).CreateClient();
      IProgress<JSONMessage> report = new Progress<JSONMessage>(msg =>
      {
        Console.WriteLine(msg.Status);
      });

      var parms = new ImagesCreateParameters { FromImage = "alpine", Tag = "3.5"};

      client.Images.CreateImageAsync(parms, null, report).GetAwaiter().GetResult();

    }
  }
}

```