### PR TITLE
ContainerListResponse should be used instead of ContainerResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DockerClient client = new DockerClientConfiguration(new Uri("npipe://./pipe/dock
 #### Example: List containers
 
 ```csharp
-IList<ContainerResponse> containers = await client.Containers.ListContainersAsync(
+IList<ContainerListResponse> containers = await client.Containers.ListContainersAsync(
 	new ContainersListParameters(){
 		Limit = 10,
     });


### PR DESCRIPTION
I'm new to DockerDotNet but I guess ContainerResponse is an old class