### PR TITLE
fix #233 , close socket after SendAsync

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -200,12 +200,14 @@ namespace Docker.DotNet
             CancellationToken token)
         {
             var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseContentRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
+            using (response)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                HandleIfErrorResponse(response.StatusCode, responseBody, errorHandlers);
 
-            HandleIfErrorResponse(response.StatusCode, responseBody, errorHandlers);
-
-            return new DockerApiResponse(response.StatusCode, responseBody);
+                return new DockerApiResponse(response.StatusCode, responseBody);
+            }
         }
 
         internal Task<Stream> MakeRequestForStreamAsync(


### PR DESCRIPTION
This PR fixed problem described in #233 ,

The reason of this problem:

First, create a docket client will create a ManageHandler with no ctor arguments:
https://github.com/Microsoft/Docker.DotNet/blob/9a740b51305180dcc87e0e9bc976e185a8e4e8ac/src/Docker.DotNet/DockerClient.cs#L108

Then, ManageHandler will use TCPSocketOpenerAsync by default:
https://github.com/Microsoft/Docker.DotNet/blob/master/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs#L23

TCPSocketOpenerAsync will open a new Socket for every request, but ProcessRequestAsync wont Dispose them
https://github.com/Microsoft/Docker.DotNet/blob/master/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs#L188

I already test this fix with my local environment and confirm it can prevent socket resource leak.
Maybe you guys want implement socket reuse but for now please take this solution and release a new version...