### PR TITLE
Reving the final appveyor release build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.124.2.{build}'
+version: '3.125.0.{build}'
 pull_requests:
   do_not_increment_build_number: true
 init:


### PR DESCRIPTION
@galvesribeiro - This will be the final commit before the new release v3.125.0. Then I will submit the registry code as a rev as its completed but this brings the core library to everyone with all the recent fixes.