### PR TITLE
Fixes an issue with JSONMessage where Aux is filled out.

### DIFF
--- a/src/Docker.DotNet/Models/Config.Generated.cs
+++ b/src/Docker.DotNet/Models/Config.Generated.cs
@@ -1,7 +1,7 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Docker.DotNet.Models
 {

--- a/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -1,7 +1,7 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Docker.DotNet.Models
 {

--- a/src/Docker.DotNet/Models/HealthConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/HealthConfig.Generated.cs
@@ -1,7 +1,7 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Docker.DotNet.Models
 {

--- a/src/Docker.DotNet/Models/JSONMessage.Generated.cs
+++ b/src/Docker.DotNet/Models/JSONMessage.Generated.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Docker.DotNet.Models
@@ -38,6 +37,6 @@ namespace Docker.DotNet.Models
         public string ErrorMessage { get; set; }
 
         [DataMember(Name = "aux", EmitDefaultValue = false)]
-        public IList<byte> Aux { get; set; }
+        public ObjectExtensionData Aux { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ObjectExtensionData.cs
+++ b/src/Docker.DotNet/Models/ObjectExtensionData.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Docker.DotNet.Models
+{
+    public class ObjectExtensionData
+    {
+        [JsonExtensionDataAttribute]
+        public IDictionary<string, object> ExtensionData { get; set; }
+    }
+}

--- a/tools/specgen/csharptype.go
+++ b/tools/specgen/csharptype.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/registry"
@@ -192,8 +193,23 @@ func calcUsings(t *CSModelType) []string {
 		}
 	}
 
-	// TODO: System sort order them.
-	sort.Strings(usings)
+	// C# convertion is that 'System' usings are first. Sort them as if they are
+	// the 'least' significant order so they appear first in the output.
+	sort.Slice(usings, func(i, j int) bool {
+		ip := strings.HasPrefix(usings[i], "System")
+		jp := strings.HasPrefix(usings[j], "System")
+		if ip && jp {
+			// System sort them.
+		} else if ip {
+			// ip has 'System' prefix and jp does not.
+			return true
+		} else if jp {
+			// jp has 'System' prefix and ip does not.
+			return false
+		}
+
+		return strings.Compare(usings[i], usings[j]) < 0
+	})
 
 	return usings
 }

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -20,6 +20,7 @@ import (
 var typeCustomizations = map[typeCustomizationKey]CSType{
 	{reflect.TypeOf(container.RestartPolicy{}), "Name"}:          {"", "RestartPolicyKind", false},
 	{reflect.TypeOf(jsonmessage.JSONMessage{}), "Time"}:          {"System", "DateTime", false},
+	{reflect.TypeOf(jsonmessage.JSONMessage{}), "Aux"}:           {"", "ObjectExtensionData", false},
 	{reflect.TypeOf(types.Container{}), "Created"}:               {"System", "DateTime", false},
 	{reflect.TypeOf(types.ContainerChange{}), "Kind"}:            {"", "FileSystemChangeKind", false},
 	{reflect.TypeOf(types.ContainerJSONBase{}), "Created"}:       {"System", "DateTime", false},


### PR DESCRIPTION
Aux is a []byte slice in go but it is actually a json object for extension data. This fixes the Aux object to allow the user to dynamically check for values rather than fixing the type.

Resolves: #252 

@Sumo-MBryant - Want to give this a shot and see if it works as expected?