### PR TITLE
Update appveyor install script to download from a stable location

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.125.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 init:
-- ps: (new-object net.webclient).DownloadFile('https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1', "C:/dotnet-install.ps1")
+- ps: (new-object net.webclient).DownloadFile('https://dot.net/v1/dotnet-install.ps1', "C:/dotnet-install.ps1")
 - ps: C:/dotnet-install.ps1 -Channel 2.0
 build_script:
 - ps: dotnet restore --no-cache


### PR DESCRIPTION
Update to the install script locations to the version hosted on the dotnet website rather than github master.

See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script

Signed-off-by: Darren Stahl <darst@microsoft.com>

cc @jterry75 