### PR TITLE
RASUtil.GetCertFromPEMFiles fails with an IndexOutOfBoundsException

### DIFF
--- a/src/Docker.DotNet.X509/RSAUtil.cs
+++ b/src/Docker.DotNet.X509/RSAUtil.cs
@@ -173,6 +173,10 @@ namespace Docker.DotNet.X509
                     index = 0;
                     while ((c = rdr.ReadChar()) != delim)
                     {
+                        if(c == '\r')
+                        {
+                            continue;
+                        }
                         line[index] = c;
                         index++;
                     }


### PR DESCRIPTION
RASUtil.GetCertFromPEMFiles fails with an IndexOutOfBoundsException when pem file contains carriage returns.

Carriage Returns working perfectly fine in DockerTLS.

By the way. The readme.md suggest to use openssl to convert the pem files to PRX instead of using RASUtil.GetCertFromPEMFiles which is more practical.