### PR TITLE
Fix to handle null web proxy settings.

### DIFF
--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Net.Http.Client
 
             try
             {
-                if (!UseProxy || Proxy.IsBypassed(request.RequestUri))
+                if (!UseProxy || (Proxy == null) || Proxy.IsBypassed(request.RequestUri))
                 {
                     return ProxyMode.None;
                 }


### PR DESCRIPTION
In cases where the Proxy is set to null, current code leads to an exception, which bubbles up to the caller. By adding a fix to check the null, we will return ProxyMode.None in such cases.