### PR TITLE
Fixes an issue with GetContainerStatsAsync

### DIFF
--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -149,7 +149,7 @@ namespace Docker.DotNet
             return this._client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/stats", queryParameters, null, null, cancellationToken);
         }
 
-        public Task GetContainerStatsAsync(string id, ContainerStatsParameters parameters, IProgress<JSONMessage> progress, CancellationToken cancellationToken = default(CancellationToken))
+        public Task GetContainerStatsAsync(string id, ContainerStatsParameters parameters, IProgress<ContainerStatsResponse> progress, CancellationToken cancellationToken = default(CancellationToken))
         {
             return StreamUtil.MonitorStreamForMessagesAsync(
                 GetContainerStatsAsync(id, parameters, cancellationToken),

--- a/src/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -157,7 +157,7 @@ namespace Docker.DotNet
         /// 500 - Server error.
         /// </remarks>
         /// <param name="id">ID or name of the container.</param>
-        Task GetContainerStatsAsync(string id, ContainerStatsParameters parameters, IProgress<JSONMessage> progress, CancellationToken cancellationToken = default(CancellationToken));
+        Task GetContainerStatsAsync(string id, ContainerStatsParameters parameters, IProgress<ContainerStatsResponse> progress, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Resize a container TTY.


### PR DESCRIPTION
Changes the response type from the stream to a ContainerStatsResponse and not JSONMessage like most of the progress API's use.

Resolves: #271