### PR TITLE
Always report error response body

### DIFF
--- a/src/Docker.DotNet/DockerApiException.cs
+++ b/src/Docker.DotNet/DockerApiException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Net;
 
 namespace Docker.DotNet

--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -202,9 +202,9 @@ namespace Docker.DotNet
             var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseContentRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
             using (response)
             {
-                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
 
-                HandleIfErrorResponse(response.StatusCode, responseBody, errorHandlers);
+                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 return new DockerApiResponse(response.StatusCode, responseBody);
             }
@@ -264,7 +264,7 @@ namespace Docker.DotNet
         {
             var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
 
-            HandleIfErrorResponse(response.StatusCode, null, errorHandlers);
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
 
             return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
@@ -277,7 +277,8 @@ namespace Docker.DotNet
             CancellationToken cancellationToken)
         {
             var response = await PrivateMakeRequestAsync(s_InfiniteTimeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, null, null, cancellationToken);
-            HandleIfErrorResponse(response.StatusCode, null, errorHandlers);
+
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
 
             var body = await response.Content.ReadAsStreamAsync();
 
@@ -308,7 +309,7 @@ namespace Docker.DotNet
         {
             var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, cancellationToken).ConfigureAwait(false);
 
-            HandleIfErrorResponse(response.StatusCode, null, errorHandlers);
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
 
             var content = response.Content as HttpConnectionResponseContent;
             if (content == null)
@@ -341,8 +342,20 @@ namespace Docker.DotNet
             return _client.SendAsync(request, completionOption, cancellationToken);
         }
 
-        private void HandleIfErrorResponse(HttpStatusCode statusCode, string responseBody, IEnumerable<ApiResponseErrorHandlingDelegate> handlers)
+        private async Task HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response, IEnumerable<ApiResponseErrorHandlingDelegate> handlers)
         {
+            bool isErrorResponse = statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest;
+
+            string responseBody = null;
+
+            if (isErrorResponse)
+            {
+                // If it is not an error response, we do not read the response body because the caller may wish to consume it.
+                // If it is an error response, we do because there is nothing else going to be done with it anyway and
+                // we want to report the response body in the error message as it contains potentially useful info.
+                responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+
             // If no customer handlers just default the response.
             if (handlers != null)
             {
@@ -353,7 +366,7 @@ namespace Docker.DotNet
             }
 
             // No custom handler was fired. Default the response for generic success/failures.
-            if (statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest)
+            if (isErrorResponse)
             {
                 throw new DockerApiException(statusCode, responseBody);
             }


### PR DESCRIPTION
This PR modifies the "make exception from error response" code to always read the response body in case of errors, as there is valuable information in there. When there is no error, the response body is not touched, as before.

Before this PR:

```
Docker API responded with status code=InternalServerError, response=
```

That error says nothing useful.

After this PR:

```
Docker API responded with status code=InternalServerError, response={"message":"Get https://registry.xx.com/v2/xx/xx-xx/manifests/cb: unauthorized: authentication required"}
```

Much better.