### PR TITLE
Allow default values of Value Types to be send to docker API as query string parameters

### DIFF
--- a/src/Docker.DotNet/QueryString.cs
+++ b/src/Docker.DotNet/QueryString.cs
@@ -42,7 +42,7 @@ namespace Docker.DotNet
                 }
 
                 // Serialize
-                if (attribute.IsRequired || !IsDefaultOfType(value))
+                if (value != null)
                 {
                     var keyStr = attribute.Name;
                     string[] valueStr;
@@ -112,16 +112,6 @@ namespace Docker.DotNet
 
             return attributedPublicProperties.Select(pi =>
                 new Tuple<PropertyInfo, TAttribType>(pi, pi.GetCustomAttribute<TAttribType>())).ToArray();
-        }
-
-        private static bool IsDefaultOfType(object o)
-        {
-            if (o is ValueType)
-            {
-                return o.Equals(Activator.CreateInstance(o.GetType()));
-            }
-
-            return o == null;
         }
     }
 


### PR DESCRIPTION
For now we can't send explicitly `false` or `0` to docker API, because default Type values are removed from query parameters. Those values works without bugs by the fact that almost all Boolean parameters in Docker API are `false` by default. 

But I think that creating code on the assumption that `false` always be default value is not good idea. 
It can lead to painful debug in future. So I think we shouldn't remove those parameters from query string.