### PR TITLE
Forwards the AddressFamily on Socket Creation

### DIFF
--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Net.Http.Client
             Exception lastException = null;
             foreach (var address in addresses)
             {
-                var s = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                var s = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
                 try
                 {
 #if (NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0)


### PR DESCRIPTION
1. Fixes a bug where we were not properly forwarding the AddressFamily of the underlying address
when creating the socket in ManagedHandler.cs

Resolves: #311