### PR TITLE
Give ImageDeleteParameters-PruneChildren a better name

### DIFF
--- a/src/Docker.DotNet/Models/ImageDeleteParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageDeleteParameters.Generated.cs
@@ -9,6 +9,6 @@ namespace Docker.DotNet.Models
         public bool? Force { get; set; }
 
         [QueryStringParameter("noprune", false, typeof(BoolQueryStringConverter))]
-        public bool? PruneChildren { get; set; }
+        public bool? NoPrune { get; set; }
     }
 }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -229,7 +229,7 @@ type ImagesSearchParameters struct {
 // ImageDeleteParameters for DELETE /images/(id)
 type ImageDeleteParameters struct {
 	Force         bool `rest:"query"`
-	PruneChildren bool `rest:"query,noprune"`
+	NoPrune       bool `rest:"query,noprune"`
 }
 
 // ImageInspectParameters for GET /images/(id)/json


### PR DESCRIPTION
Since PruneChildren = true actually means no prune children in the code when sending request to Docker daemon and this parameter is called "--no-prune" in Docker API, so Let us give it a better name here.