### PR TITLE
Automatic detection of Windows / Unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,15 @@ using Docker.DotNet;
 DockerClient client = new DockerClientConfiguration(new Uri("http://ubuntu-docker.cloudapp.net:4243"))
      .CreateClient();
 ```
-or to connect to your local [Docker for Windows](https://docs.docker.com/docker-for-windows/) daemon using named pipes:
+or to connect to your local [Docker for Windows](https://docs.docker.com/docker-for-windows/) daemon using named pipes or your local [Docker for Mac](https://docs.docker.com/docker-for-mac/) daemon using Unix sockets:
 
 ```csharp
 using Docker.DotNet;
-DockerClient client = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"))
+DockerClient client = new DockerClientConfiguration()
      .CreateClient();
 ```
 
-or to connect to your local [Docker for Mac](https://docs.docker.com/docker-for-mac/) daemon using Unix sockets:
-
-```csharp
-using Docker.DotNet;
-DockerClient client = new DockerClientConfiguration(new Uri("unix:/var/run/docker.sock"))
-     .CreateClient();
-```
+For a custom endpoint, you can also pass a named pipe or a Unix socket to the `DockerClientConfiguration` constructor. For example: `new Uri("npipe://./pipe/docker_engine")` or `new Uri("unix:/var/run/docker.sock")`
 
 #### Example: List containers
 

--- a/src/Docker.DotNet/Docker.DotNet.csproj
+++ b/src/Docker.DotNet/Docker.DotNet.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Docker.DotNet
@@ -10,6 +11,17 @@ namespace Docker.DotNet
         public Credentials Credentials { get; internal set; }
 
         public TimeSpan DefaultTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
+
+        private static Uri LocalDockerUri()
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return isWindows ? new Uri("npipe://./pipe/docker_engine") : new Uri("unix:/var/run/docker.sock");
+        }
+
+        public DockerClientConfiguration(Credentials credentials = null, TimeSpan defaultTimeout = default(TimeSpan))
+            : this(LocalDockerUri(), credentials, defaultTimeout)
+        {
+        }
 
         public DockerClientConfiguration(Uri endpoint, Credentials credentials = null,
             TimeSpan defaultTimeout = default(TimeSpan))

--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -14,7 +14,7 @@ namespace Docker.DotNet.Tests
 
         public ISystemOperationsTests()
         {
-            _client = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine")).CreateClient();
+            _client = new DockerClientConfiguration().CreateClient();
         }
 
         [Fact]

--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -17,7 +17,7 @@ namespace Docker.DotNet.Tests
             _client = new DockerClientConfiguration().CreateClient();
         }
 
-        [Fact]
+        [SupportedOSPlatformsFact(Platform.Windows)]
         public void DockerService_IsRunning()
         {
             var services = ServiceController.GetServices();

--- a/test/Docker.DotNet.Tests/SupportedOSPlatformsFactAttribute.cs
+++ b/test/Docker.DotNet.Tests/SupportedOSPlatformsFactAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Docker.DotNet.Tests
+{
+    public enum Platform
+    {
+        Linux,
+        OSX,
+        Windows
+    }
+    
+    public sealed class SupportedOSPlatformsFactAttribute : FactAttribute
+    {
+        private static Platform CurrentPlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return Platform.Linux;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return Platform.OSX;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return Platform.Windows;
+            throw new PlatformNotSupportedException();
+        }
+
+        public SupportedOSPlatformsFactAttribute(params Platform[] supportedPlatforms)
+        {
+            var currentPlatform = CurrentPlatform();
+            var isSupported = supportedPlatforms.Contains(currentPlatform);
+            Skip = isSupported ? null : $"Not applicable to {currentPlatform}";
+        }
+    }
+}


### PR DESCRIPTION
* Added a new DockerClientConfiguration constructor that automatically detect the current platform and chooses the local docker endpoint Uri using `npipe://./pipe/docker_engine` on Windows and `unix:/var/run/docker.sock` otherwise.

* Updated documentation to reflect that new feature

* Updated the tests to use this new constructor. The tests can now run on Linux, macOS and Windows.