### PR TITLE
Set NamedPipeClientSteam PipeOptions to asynchronous and make timeout configurable

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -19,10 +19,6 @@ namespace Docker.DotNet
     {
         private const string UserAgent = "Docker.DotNet";
 
-        // NamedPipeClientStream handles file not found by polling until the server arrives. Use a short
-        // timeout so that the user doesn't get stuck waiting for a dockerd instance that is not running.
-        private static readonly TimeSpan DefaultNamedPipeConnectTimeout = TimeSpan.FromMilliseconds(100);
-
         private static readonly TimeSpan s_InfiniteTimeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
 
         private readonly HttpClient _client;
@@ -76,7 +72,7 @@ namespace Docker.DotNet
                     uri = new UriBuilder("http", pipeName).Uri;
                     handler = new ManagedHandler(async (host, port, cancellationToken) =>
                     {
-                        int timeout = Math.Max(this.DefaultTimeout.Milliseconds, DefaultNamedPipeConnectTimeout.Milliseconds);
+                        int timeout = this.Configuration.NamedPipeConnectTimeout.Milliseconds;
                         var stream = new NamedPipeClientStream(serverName, pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
                         var dockerStream = new DockerPipeStream(stream);
 

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -12,6 +12,10 @@ namespace Docker.DotNet
 
         public TimeSpan DefaultTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
 
+        // NamedPipeClientStream handles file not found by polling until the server arrives. Use a short
+        // timeout so that the user doesn't get stuck waiting for a dockerd instance that is not running.
+        public TimeSpan NamedPipeConnectTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
+
         private static Uri LocalDockerUri()
         {
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -12,8 +12,6 @@ namespace Docker.DotNet
 
         public TimeSpan DefaultTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
 
-        // NamedPipeClientStream handles file not found by polling until the server arrives. Use a short
-        // timeout so that the user doesn't get stuck waiting for a dockerd instance that is not running.
         public TimeSpan NamedPipeConnectTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
         private static Uri LocalDockerUri()


### PR DESCRIPTION
The timeout for calling Connect on the NamedPipeClientStream used to communicate with the dockerd instance was hardcoded to 100 milliseconds. Made it so it can be configured in DockerClientConfiguration.
Also set the PipeOptions in the NamedPipeClientStream constructor to Asynchronous 