### PR TITLE
Fix junk characters in GetContainerLogs

### DIFF
--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -112,6 +112,25 @@ namespace Docker.DotNet
                 progress);
         }
 
+        public async Task<MultiplexedStream> GetContainerLogsAsync(string id, bool tty, ContainerLogsParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            IQueryString queryParameters = new QueryString<ContainerLogsParameters>(parameters);
+
+            Stream result = await this._client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/logs", queryParameters, cancellationToken).ConfigureAwait(false);
+
+            return new MultiplexedStream(result, !tty);
+        }
+
         public async Task<IList<ContainerFileSystemChangeResponse>> InspectChangesAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(id))

--- a/src/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -98,7 +98,19 @@ namespace Docker.DotNet
         [Obsolete("The stream returned by this method won't be demultiplexed properly if the container was created without a TTY. Use GetContainerLogsAsync(string, bool, ContainerLogsParameters, CancellationToken) instead")]
         Task<Stream> GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
-        [Obsolete("The strings reported by this method will contain junk if the container was created without a TTY. Use GetContainerLogsAsync(string, bool, ContainerLogsParameters, CancellationToken) instead")]
+        /// <summary>
+        /// Gets the logs from a container.
+        /// This method is only suited for containers created with a TTY. For containers created without a TTY, use
+        /// <see cref="GetContainerLogsAsync(string, bool, ContainerLogsParameters, CancellationToken)"/> instead.
+        /// </summary>
+        /// <param name="id">ID or name of the container.</param>
+        /// <param name="parameters">The parameters used to retrieve the logs.</param>
+        /// <param name="cancellationToken">A token used to cancel this operation.</param>
+        /// <param name="progress">
+        /// The class that will receive the log lines.
+        /// Every reported string represents one log line, with its terminating newline removed.
+        /// </param>
+        /// <returns>A Task that will complete once all log lines have been read, or once the container has exited if Follow is set to <see langword="true"/>.</returns>
         Task GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken, IProgress<string> progress);
 
         /// <summary>

--- a/src/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -95,10 +95,22 @@ namespace Docker.DotNet
         /// 500 - Server error.
         /// </remarks>
         /// <param name="id">ID or name of the container.</param>
-        [Obsolete("Use 'Task GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken, IProgress<string> progress)'")]
+        [Obsolete("The stream returned by this method won't be demultiplexed properly if the container was created without a TTY. Use GetContainerLogsAsync(string, bool, ContainerLogsParameters, CancellationToken) instead")]
         Task<Stream> GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
+        [Obsolete("The strings reported by this method will contain junk if the container was created without a TTY. Use GetContainerLogsAsync(string, bool, ContainerLogsParameters, CancellationToken) instead")]
         Task GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken, IProgress<string> progress);
+
+        /// <summary>
+        /// Gets the <code>stdout</code> and <code>stderr</code> logs from a container.
+        /// This endpoint works only for containers with the <code>json-file</code> or <code>journald</code> logging driver.
+        /// </summary>
+        /// <param name="id">ID or name of the container.</param>
+        /// <param name="tty">If the container was created with a TTY or not. If <see langword="false" />, the returned stream is multiplexed.</param>
+        /// <param name="parameters">The parameters used to retrieve the logs.</param>
+        /// <param name="cancellationToken">A token used to cancel this operation.</param>
+        /// <returns>A stream with the retrieved logs. If the container wasn't created with a TTY, this stream is multiplexed.</returns>
+        Task<MultiplexedStream> GetContainerLogsAsync(string id, bool tty, ContainerLogsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get changes on a container's filesystem.

--- a/src/Docker.DotNet/MultiplexedStream.cs
+++ b/src/Docker.DotNet/MultiplexedStream.cs
@@ -13,7 +13,7 @@ namespace Docker.DotNet
 {
     public class MultiplexedStream : IDisposable
     {
-        private readonly WriteClosableStream _stream;
+        private readonly Stream _stream;
         private TargetStream _target;
         private int _remaining;
         private readonly byte[] _header = new byte[8];
@@ -21,7 +21,7 @@ namespace Docker.DotNet
 
         const int BufferSize = 81920;
 
-        public MultiplexedStream(WriteClosableStream stream, bool multiplexed)
+        public MultiplexedStream(Stream stream, bool multiplexed)
         {
             _stream = stream;
             _multiplexed = multiplexed;
@@ -43,7 +43,10 @@ namespace Docker.DotNet
 
         public void CloseWrite()
         {
-            _stream.CloseWrite();
+            if (_stream is WriteClosableStream closable)
+            {
+                closable.CloseWrite();
+            }
         }
 
         public Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)


### PR DESCRIPTION
This is a pull request that fixes #359 

It creates a new overload of  `IContainerOperations.GetContainerLogsAsync` that returns a `MultiplexedStream`, allowing for the logs to be multiplexed for containers without a TTY.

Unlike what the documentation said, I was unable to hijack the connection when `follow` was set,
it would always fail with a "Chunked or Content-Length streams cannot be hijacked" error.

However, I've tested it with all possible combinations of TTY on/off and Follow on/off, and it seems to work fine on all cases even without hijacking the connection.
