### PR TITLE
progress can be null in CreateImageAsync

### DIFF
--- a/src/Docker.DotNet/Endpoints/ImageOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ImageOperations.cs
@@ -60,12 +60,12 @@ namespace Docker.DotNet
             return this._client.MakeRequestForStreamAsync(this._client.NoErrorHandlers, HttpMethod.Post, "build", queryParameters, data, cancellationToken);
         }
 
-        public Task CreateImageAsync(ImagesCreateParameters parameters, AuthConfig authConfig, IProgress<JSONMessage> progress, CancellationToken cancellationToken = default(CancellationToken))
+        public Task CreateImageAsync(ImagesCreateParameters parameters, AuthConfig authConfig, IProgress<JSONMessage> progress = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateImageAsync(parameters, null, authConfig, progress, cancellationToken);
         }
 
-        public Task CreateImageAsync(ImagesCreateParameters parameters, Stream imageStream, AuthConfig authConfig, IProgress<JSONMessage> progress, CancellationToken cancellationToken = default(CancellationToken))
+        public Task CreateImageAsync(ImagesCreateParameters parameters, Stream imageStream, AuthConfig authConfig, IProgress<JSONMessage> progress = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (parameters == null)
             {

--- a/src/Docker.DotNet/Endpoints/StreamUtil.cs
+++ b/src/Docker.DotNet/Endpoints/StreamUtil.cs
@@ -45,7 +45,8 @@ namespace Docker.DotNet.Models
                                 var prog = client.JsonSerializer.DeserializeObject<T>(line);
                                 if (prog == null) continue;
 
-                                progress.Report(prog);
+                                if(progress!= null)
+                                    progress.Report(prog);
                             }
                         }
                         catch (ObjectDisposedException)


### PR DESCRIPTION
Optional progress can be very useful (instead of passing an empty one: new Progress<JSONMessage>( JSONMessage _ => {}) )