### PR TITLE
Make ExecOperations available

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -43,6 +43,7 @@ namespace Docker.DotNet
             Tasks = new TasksOperations(this);
             Volumes = new VolumeOperations(this);
             Plugin = new PluginOperations(this);
+            Exec = new ExecOperations(this);
 
             ManagedHandler handler;
             var uri = Configuration.EndpointBaseUri;
@@ -145,6 +146,8 @@ namespace Docker.DotNet
         public ISystemOperations System { get; }
 
         public IPluginOperations Plugin { get; }
+
+        public IExecOperations Exec { get; }
 
         internal JsonSerializer JsonSerializer { get; }
 

--- a/src/Docker.DotNet/Endpoints/ExecOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ExecOperations.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Docker.DotNet.Endpoints
+namespace Docker.DotNet
 {
     internal class ExecOperations : IExecOperations
     {


### PR DESCRIPTION
Do you have any reason not to make ExecOperations available through DockerClient?

Thanks!