### PR TITLE
Fix HTTP version to 1.1

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -424,7 +424,7 @@ namespace Docker.DotNet
 
             var request = new HttpRequestMessage(method, HttpUtility.BuildUri(_endpointBaseUri, this._requestedApiVersion, path, queryString));
 
-            request.Version = new Version(1, 11);
+            request.Version = new Version(1, 1);
 
             request.Headers.Add("User-Agent", UserAgent);
 

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Net.Http.Client
             // CONNECT server.example.com:80 HTTP / 1.1
             // Host: server.example.com:80
             var connectRequest = new HttpRequestMessage();
-            connectRequest.Version = new Version(1, 11);
+            connectRequest.Version = new Version(1, 1);
 
             connectRequest.Headers.ProxyAuthorization = request.Headers.ProxyAuthorization;
             connectRequest.Method = new HttpMethod("CONNECT");


### PR DESCRIPTION
It looks like #299 fixed #285 by inventing one point eleven. Works fine from a "not using HTTP/2" perspective, but in my weird use-case of Kestrel proxying a docker endpoint:

````
dbug: Microsoft.AspNetCore.Server.Kestrel[17]
      Connection id "0HLT1H1C8TPI1" bad request data: "Unrecognized HTTP version: 'HTTP/1.11'"
`````

`HttpVersion.Version11` not available on all targets.