### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,13 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,8 +39,13 @@ jobs:
           DNF_CODESIGN_CONFIG: ${{secrets.DNF_CODESIGN_CONFIG}}
           DNF_CODESIGN_USER: ${{secrets.DNF_CODESIGN_USER}}
           DNF_CODESIGN_SECRET: ${{secrets.DNF_CODESIGN_SECRET}}
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push packages to NuGet.org
-        run: dotnet nuget push ./packages/Docker.DotNet.*.nupkg --skip-duplicate -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./packages/Docker.DotNet.*.nupkg --skip-duplicate -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Create Release
         uses: actions/github-script@v5
         with:


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (Docker.DotNet in this case).  
- The old `secrets.NUGET_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `Docker.DotNet`).  
   - **Repository owner:** your GitHub org/user (e.g. `dotnet`).  
   - **Repository name:** repository name (e.g. `Docker.DotNet`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `publish.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.
